### PR TITLE
[feat] shop피드 스켈레톤 ui 및 라우팅 문제 해결

### DIFF
--- a/components/Shop/Organisms/FilterModal/utils.ts
+++ b/components/Shop/Organisms/FilterModal/utils.ts
@@ -101,8 +101,8 @@ export const getFilterElement = (
   const { style, price, color, fit, length, clothesSize } = states;
   const common = {
     style: style.join(','),
-    price_goe: Math.max(...price).toString(),
-    price_loe: Math.min(...price).toString(),
+    price_goe: Math.min(...price).toString(),
+    price_loe: Math.max(...price).toString(),
     color: '',
     fit: '',
     length: '',

--- a/components/Shop/Organisms/ProductItemList/NoProductView.tsx
+++ b/components/Shop/Organisms/ProductItemList/NoProductView.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 function NoProductView({ isNoProducts, isLoading, isFetching }: Props) {
   return (
-    (!isLoading && !isFetching && !isNoProducts && (
+    (!isLoading && !isFetching && isNoProducts && (
       <div className={$['no-products']}>
         <Span fontWeight={500}>상품 결과가 없습니다.</Span>
       </div>

--- a/components/Shop/Organisms/ProductItemList/ProductListView.tsx
+++ b/components/Shop/Organisms/ProductItemList/ProductListView.tsx
@@ -8,7 +8,7 @@ import $ from './style.module.scss';
 type Props = {
   isFetching: boolean;
   intersectRef: React.RefObject<HTMLDivElement>;
-  itemList: res.ProductSummary[];
+  itemList?: res.ProductSummary[];
   noProducts: React.ReactNode;
 };
 
@@ -17,11 +17,13 @@ function ProductListView(viewProps: Props) {
 
   return (
     <>
-      <article className={$['product-list']}>
-        {itemList.map((item) => (
-          <ProductItem key={item.id} {...item} />
-        ))}
-      </article>
+      {itemList && (
+        <article className={$['product-list']}>
+          {itemList.map((item) => (
+            <ProductItem key={item.id} {...item} />
+          ))}
+        </article>
+      )}
       {noProducts}
       <div ref={intersectRef} />
       {isFetching && <Loading />}

--- a/components/Shop/Organisms/ProductItemList/index.tsx
+++ b/components/Shop/Organisms/ProductItemList/index.tsx
@@ -32,6 +32,7 @@ function ProductItemList(listProps: Props) {
     fetchNextPage,
     refetch,
     remove,
+    isFetched,
   } = useProductItemListQuery(productList);
 
   const onRefresh = () => {
@@ -53,19 +54,14 @@ function ProductItemList(listProps: Props) {
   const pullDownThreshold = 60;
   const maxPullDownDistance = 90;
 
-  if (isLoading) {
-    return <ShopSkeleton itemNum={10} />;
-  }
-
-  const items = data?.pages;
-  if (!items) return null;
+  const items = data?.pages; // TODO: error 캐치 필요
 
   const itemList = items?.reduce((acc: res.ProductSummary[], cur) => {
     acc.push(...cur.items);
     return acc;
   }, []);
 
-  const isNoProducts = !!itemList.length;
+  const isNoProducts = (itemList && !itemList.length) || false;
 
   const noProducts = (
     <NoProductView
@@ -76,6 +72,17 @@ function ProductItemList(listProps: Props) {
       }}
     />
   );
+
+  const commonProducts =
+    !itemList && isLoading ? (
+      <ShopSkeleton itemNum={10} />
+    ) : (
+      <ProductListView
+        {...{ intersectRef, isFetching, noProducts }}
+        itemList={itemList}
+      />
+    );
+
   if (needPullToRefresh) {
     return (
       <ProductListWrapperView {...{ paddingTop, paddingBottom }}>
@@ -87,10 +94,7 @@ function ProductItemList(listProps: Props) {
             maxPullDownDistance,
           }}
         >
-          <ProductListView
-            {...{ intersectRef, isFetching, noProducts }}
-            itemList={itemList}
-          />
+          {commonProducts}
         </PullToRefresh>
       </ProductListWrapperView>
     );
@@ -98,10 +102,7 @@ function ProductItemList(listProps: Props) {
 
   return (
     <ProductListWrapperView {...{ paddingTop, paddingBottom }}>
-      <ProductListView
-        {...{ intersectRef, isFetching, noProducts }}
-        itemList={itemList}
-      />
+      {commonProducts}
     </ProductListWrapperView>
   );
 }

--- a/components/Shop/Organisms/ProductItemList/index.tsx
+++ b/components/Shop/Organisms/ProductItemList/index.tsx
@@ -32,7 +32,6 @@ function ProductItemList(listProps: Props) {
     fetchNextPage,
     refetch,
     remove,
-    isFetched,
   } = useProductItemListQuery(productList);
 
   const onRefresh = () => {

--- a/components/Shop/Organisms/ProductItemList/index.tsx
+++ b/components/Shop/Organisms/ProductItemList/index.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 
 import Loading from '@atoms/Loading';
 import PullToRefresh from '@templates/PullToRefresh';
+import ShopSkeleton from '@templates/Skeleton/shop';
 import { useIntersect } from 'hooks';
 import { useProductItemListQuery } from 'hooks/api/shop';
 
@@ -52,6 +53,10 @@ function ProductItemList(listProps: Props) {
   const pullDownThreshold = 60;
   const maxPullDownDistance = 90;
 
+  if (isLoading) {
+    return <ShopSkeleton itemNum={10} />;
+  }
+
   const items = data?.pages;
   if (!items) return null;
 
@@ -71,7 +76,6 @@ function ProductItemList(listProps: Props) {
       }}
     />
   );
-
   if (needPullToRefresh) {
     return (
       <ProductListWrapperView {...{ paddingTop, paddingBottom }}>

--- a/components/Shop/Organisms/ShopHeader/index.tsx
+++ b/components/Shop/Organisms/ShopHeader/index.tsx
@@ -8,6 +8,7 @@ import { findCodeByProp } from 'components/Upload/organisms/Dialog/utils';
 import { useQueryRouter } from 'hooks';
 
 import $ from './style.module.scss';
+import { isRootCategory } from './utils';
 
 type Props = {
   genderQuery: string;
@@ -22,9 +23,10 @@ type Props = {
 };
 
 function ShopHeader(headerProps: Props) {
-  const queryCategory = useQueryRouter('category');
-  const queryOrder = useQueryRouter('order');
-  const queryHideSold = useQueryRouter('hide_sold');
+  const pushCtgr = useQueryRouter('category');
+  const replaceCtgr = useQueryRouter('category', 'REPLACE');
+  const queryOrder = useQueryRouter('order', 'REPLACE');
+  const queryHideSold = useQueryRouter('hide_sold', 'REPLACE');
   const { orderQuery, hideSoldQuery } = headerProps;
   const { genderSelectMenu, mainSelectMenu, subSelectMenu } = headerProps;
   const { genderQuery, mainQuery, subQuery, breadCrumb } = headerProps;
@@ -32,6 +34,8 @@ function ShopHeader(headerProps: Props) {
   const categoryData = isSeletedSub ? subSelectMenu : mainSelectMenu;
   const selectedMenu = isSeletedSub ? subQuery : mainQuery;
   const mainCategory = findCodeByProp(mainSelectMenu, mainQuery, 'id');
+
+  const queryCategory = isRootCategory(subQuery) ? pushCtgr : replaceCtgr;
 
   return (
     <header className={$.header}>

--- a/components/Shop/Organisms/ShopHeader/index.tsx
+++ b/components/Shop/Organisms/ShopHeader/index.tsx
@@ -46,11 +46,11 @@ function ShopHeader(headerProps: Props) {
         selectedMenu={genderQuery}
       />
       <CategoryBox
-        {...{ onClick: queryCategory, isSeletedSub, selectedMenu }}
+        {...{ onClick: queryCategory, isSeletedSub, selectedMenu }} // TODO: 렌더링 최적화
         data={categoryData}
       />
       <SortBox
-        {...{ onSoldClick: queryHideSold, onOrderClick: queryOrder }}
+        {...{ onSoldClick: queryHideSold, onOrderClick: queryOrder }} // TODO: 렌더링 최적화
         data={orderData}
         hideSold={hideSoldQuery}
         selectedMenu={orderQuery}

--- a/components/Shop/Organisms/ShopHeader/utils.ts
+++ b/components/Shop/Organisms/ShopHeader/utils.ts
@@ -1,0 +1,2 @@
+export const isRootCategory = (subQuery?: string) =>
+  subQuery?.slice(-3) === '000' || !subQuery;

--- a/components/shared/atoms/BackBtn.tsx
+++ b/components/shared/atoms/BackBtn.tsx
@@ -16,7 +16,10 @@ type Props = {
 function BackBtn({ className, color, url, onClick }: Props) {
   const router = useRouter();
   const handleClick = useCallback(() => {
-    if (onClick) onClick();
+    if (onClick) {
+      onClick();
+      return;
+    }
     if (url) router.replace(url);
     else router.back();
   }, [onClick, router, url]);

--- a/components/shared/templates/Skeleton/shop/index.tsx
+++ b/components/shared/templates/Skeleton/shop/index.tsx
@@ -1,0 +1,51 @@
+import classnames from 'classnames';
+import $$ from 'components/Shop/molecules/ProductItem/style.module.scss';
+import $ from 'components/Shop/Organisms/ProductItemList/style.module.scss';
+
+import sklt from './style.module.scss';
+
+type Props = {
+  itemNum: number;
+  paddingTop?: string;
+  paddingBottom?: string;
+};
+
+function ShopSkeleton(skeletonProps: Props) {
+  const { paddingTop, paddingBottom, itemNum } = skeletonProps;
+  const skeletonItemList = Array.from({ length: itemNum }, (_, i) => i);
+
+  return (
+    <section
+      style={{ paddingTop, paddingBottom }}
+      className={$['product-container']}
+    >
+      <article className={$['product-list']}>
+        {skeletonItemList.map((item) => (
+          <div key={item} className={$$['product-item']}>
+            <div
+              className={classnames(
+                $$['product-img'],
+                sklt['skeleton-product-img'],
+              )}
+            />
+            <div
+              className={classnames($$['text-box'], sklt['skeleton-text-box'])}
+            >
+              <div className={classnames($$.title, sklt['skeleton-title'])} />
+              <div
+                className={classnames(
+                  $$['size-like'],
+                  sklt['skeleton-size-like'],
+                )}
+              />
+              <div className={classnames($$.price, sklt['skeleton-price'])} />
+              <div className={classnames($$.date, sklt['skeleton-date'])} />
+            </div>
+          </div>
+        ))}
+      </article>
+    </section>
+  );
+}
+
+export default ShopSkeleton;

--- a/components/shared/templates/Skeleton/shop/index.tsx
+++ b/components/shared/templates/Skeleton/shop/index.tsx
@@ -6,45 +6,38 @@ import sklt from './style.module.scss';
 
 type Props = {
   itemNum: number;
-  paddingTop?: string;
-  paddingBottom?: string;
 };
 
 function ShopSkeleton(skeletonProps: Props) {
-  const { paddingTop, paddingBottom, itemNum } = skeletonProps;
+  const { itemNum } = skeletonProps;
   const skeletonItemList = Array.from({ length: itemNum }, (_, i) => i);
 
   return (
-    <section
-      style={{ paddingTop, paddingBottom }}
-      className={$['product-container']}
-    >
-      <article className={$['product-list']}>
-        {skeletonItemList.map((item) => (
-          <div key={item} className={$$['product-item']}>
+    <article className={$['product-list']}>
+      {skeletonItemList.map((item) => (
+        <div key={item} className={$$['product-item']}>
+          <div
+            className={classnames(
+              $$['product-img'],
+              sklt['skeleton-product-img'],
+            )}
+          />
+          <div
+            className={classnames($$['text-box'], sklt['skeleton-text-box'])}
+          >
+            <div className={classnames($$.title, sklt['skeleton-title'])} />
             <div
               className={classnames(
-                $$['product-img'],
-                sklt['skeleton-product-img'],
+                $$['size-like'],
+                sklt['skeleton-size-like'],
               )}
             />
-            <div
-              className={classnames($$['text-box'], sklt['skeleton-text-box'])}
-            >
-              <div className={classnames($$.title, sklt['skeleton-title'])} />
-              <div
-                className={classnames(
-                  $$['size-like'],
-                  sklt['skeleton-size-like'],
-                )}
-              />
-              <div className={classnames($$.price, sklt['skeleton-price'])} />
-              <div className={classnames($$.date, sklt['skeleton-date'])} />
-            </div>
+            <div className={classnames($$.price, sklt['skeleton-price'])} />
+            <div className={classnames($$.date, sklt['skeleton-date'])} />
           </div>
-        ))}
-      </article>
-    </section>
+        </div>
+      ))}
+    </article>
   );
 }
 

--- a/components/shared/templates/Skeleton/shop/style.module.scss
+++ b/components/shared/templates/Skeleton/shop/style.module.scss
@@ -1,0 +1,31 @@
+.skeleton-product-img {
+  @include loading();
+  border-radius: 10px;
+}
+
+.skeleton-text-box {
+  overflow: hidden;
+
+  .skeleton-title {
+    height: 19px;
+    width: 80%;
+    @include loading();
+  }
+
+  .skeleton-size-like {
+    height: 17px;
+    @include loading();
+  }
+
+  .skeleton-price {
+    width: 50%;
+    height: 19px;
+    @include loading();
+  }
+
+  .skeleton-date {
+    width: 30%;
+    height: 14px;
+    @include loading();
+  }
+}

--- a/constants/queryString/index.ts
+++ b/constants/queryString/index.ts
@@ -1,3 +1,5 @@
+import { orderData } from '..';
+
 export const queries: readonly (keyof Omit<req.ShopFeed, 'page' | 'size'>)[] = [
   'category',
   'hide_sold',
@@ -10,3 +12,8 @@ export const queries: readonly (keyof Omit<req.ShopFeed, 'page' | 'size'>)[] = [
   'length',
   'clothes_size',
 ];
+
+export const queryData: [keyof Omit<req.ShopFeed, 'page' | 'size'>, string?][] =
+  ['1', 'true', orderData[0].code, '', '', '', '', '', '', ''].map(
+    (prev, i) => [queries[i], prev],
+  );

--- a/hooks/useQueryRouter.ts
+++ b/hooks/useQueryRouter.ts
@@ -2,18 +2,22 @@ import { useRouter } from 'next/router';
 
 import { useCallback } from 'react';
 
-function useQueryRouter(queryName: string) {
+import { RouterFunc } from '#types/index';
+
+function useQueryRouter(queryName: string, type?: RouterFunc) {
   const router = useRouter();
+  const routerFunc = type === 'REPLACE' ? router.replace : router.push;
+
   const queryFunc = useCallback(
     (value?: string) =>
-      router.push(
+      routerFunc(
         {
           query: { ...router.query, [queryName]: value },
         },
         undefined,
         { shallow: true },
       ),
-    [queryName, router],
+    [queryName, router.query, routerFunc],
   );
   return queryFunc;
 }

--- a/hooks/useSearch.ts
+++ b/hooks/useSearch.ts
@@ -1,13 +1,22 @@
 import { useRouter } from 'next/router';
 
+import { getQueryStringObj, getQueriesArr } from 'utils';
+
 function useSearch(target: string) {
   return useRouter().query[target]?.toString() || '';
 }
 
-function useMultipleSearch(targets: readonly string[]) {
-  // TODO: add typescript code array to tuple
+function useMultipleSearch<T extends string>(
+  queryDatas: [T, string?][],
+  targets: readonly string[],
+) {
   const router = useRouter();
-  return targets.map((target) => router.query[target]?.toString() || '');
+  return getQueryStringObj(
+    getQueriesArr<T>(
+      queryDatas,
+      targets.map((target) => router.query[target]),
+    ),
+  );
 }
 
 export { useSearch, useMultipleSearch };

--- a/pages/shop/index.tsx
+++ b/pages/shop/index.tsx
@@ -109,9 +109,8 @@ function Shop() {
     <>
       <HeadMeta title="re:Fashion | 상품 피드" url={`${seoData.url}/shop`} />
       <ShopHeader {...props} />
-
-      <ProductItemList needPullToRefresh {...{ queryStringObj }} />
-
+      <ProductItemList needPullToRefresh {...{ queryStringObj }} />{' '}
+      {/** TODO: 렌더링 최적화 */}
       <Footer />
     </>
   );

--- a/pages/shop/index.tsx
+++ b/pages/shop/index.tsx
@@ -29,21 +29,14 @@ export async function getServerSideProps({ query }: GetServerSidePropsContext) {
   const { category, order, hide_sold } = query;
   const { style, price_goe, price_loe, color, fit, length, clothes_size } =
     query;
-  const queryClient = new QueryClient();
+  const arr1 = [category, order, hide_sold];
+  const arr2 = [style, price_goe, price_loe, color, fit, length, clothes_size];
+  const queryArr = [...arr1, ...arr2];
 
-  const queryObj = getQueriesArr(queryData, [
-    category,
-    hide_sold,
-    order,
-    style,
-    price_goe,
-    price_loe,
-    color,
-    fit,
-    length,
-    clothes_size,
-  ]);
+  const queryObj = getQueriesArr(queryData, queryArr);
   const queryStringObj = getQueryStringObj(queryObj);
+
+  const queryClient = new QueryClient();
 
   await queryClient.prefetchQuery('category', () => getCategoryData());
   await queryClient.prefetchInfiniteQuery(

--- a/pages/shop/index.tsx
+++ b/pages/shop/index.tsx
@@ -26,10 +26,10 @@ import { useMultipleSearch } from 'hooks';
 import { getQueryStringObj, getQueriesArr } from 'utils';
 
 export async function getServerSideProps({ query }: GetServerSidePropsContext) {
-  const { category, order, hide_sold } = query;
+  const { category, hide_sold, order } = query;
   const { style, price_goe, price_loe, color, fit, length, clothes_size } =
     query;
-  const arr1 = [category, order, hide_sold];
+  const arr1 = [category, hide_sold, order]; // TODO: obj로 변경
   const arr2 = [style, price_goe, price_loe, color, fit, length, clothes_size];
   const queryArr = [...arr1, ...arr2];
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -12,3 +12,5 @@ export type ImgProps = {
 export type DefaultData = { id?: string; name: string; code: string };
 
 export type UrlQuery = string | string[] | undefined;
+
+export type RouterFunc = 'REPLACE' | 'PUSH' | 'BACK';

--- a/types/index.ts
+++ b/types/index.ts
@@ -10,3 +10,5 @@ export type ImgProps = {
 } & ImgBasicProps;
 
 export type DefaultData = { id?: string; name: string; code: string };
+
+export type UrlQuery = string | string[] | undefined;

--- a/utils/getQueryString.ts
+++ b/utils/getQueryString.ts
@@ -1,5 +1,25 @@
+import { UrlQuery } from '#types/index';
+
 function getQueryString(queryObj: { [key: string]: string }) {
   return decodeURIComponent(new URLSearchParams(queryObj).toString());
 }
 
-export default getQueryString;
+function getQueryStringObj<T extends string>(
+  queries: [T, string][],
+): Record<T, string> {
+  return queries.reduce((acc, [key, value]) => {
+    return { ...acc, [key]: value };
+  }, {} as Record<T, string>);
+}
+
+function getQueriesArr<T>(
+  datas: [T, string?][],
+  urlQueries: UrlQuery[],
+): [T, string][] {
+  return datas.map(([key, value], i) => [
+    key,
+    (urlQueries[i] || value || '').toString(),
+  ]);
+}
+
+export { getQueryString, getQueryStringObj, getQueriesArr };

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -2,7 +2,11 @@ import { deepClone } from 'utils/deepClone';
 
 import { arrToString } from './arrToString';
 import { filterMaxPrice, validatePriceRange } from './filterValue';
-import getQueryString from './getQueryString';
+import {
+  getQueriesArr,
+  getQueryString,
+  getQueryStringObj,
+} from './getQueryString';
 import { getJudgeCategory, getMeasureElement } from './measure';
 import { mergeObjInArr } from './mergeObjInArr';
 import {
@@ -27,4 +31,6 @@ export {
   getMeasureElement,
   getQueryString,
   validatePriceRange,
+  getQueryStringObj,
+  getQueriesArr,
 };


### PR DESCRIPTION
## 💡 이슈
resolve #98 

## 🤩 개요
shop피드 스켈레톤 ui 및 라우팅 문제 해결

## 🧑‍💻 작업 사항

### shop피드 스켈레톤 ui
기존 loading 애니메이션을 활용해 스켈레톤 ui를 적용했습니다. 한가지 고민은 Error Boundary 사용 시 ProductView에 적용해야 하는데 따로 컴포넌트를 나눠야 할 것 같아 이 부분이 고민됩니다.

### 라우팅 문제 해결
기존 shop피드에서는 router.push로만 구현되어 있었습니다. 이렇게 되면 문제점은 사용자는 분명
성별 -> 메인 -> 서브 카테고리로 흘러갈 때, 서브 카테고리의 여러 항목들을 클릭한 후 뒤로가기를 누르면 메인 카테고리로 가기를 원할 것입니다. 하지만 기존 방식에서는 이전에 눌렀던 서브 카테고리로 이동되는 UX의 문제점이 있었습니다.

이를 해결하기 위해 `isRootCategory`조건을 만들었습니다. `subQuery?.slice(-3) === '000' || !subQuery` 서브 카테고리가 없거나 뒷부분 자른 문자열이 000이면 루트 카테고리이므로 이때는 `router.replace`를 실행하도록하여 해결했습니다.

### shop 피드 코드 개선 작업
기존 shop 피드 페이지에서는 코드 라인이 150줄이 넘어가며 `query string`부분을 하드코딩했다는 이슈가 있었습니다. 이를 해결하기 위해 `useMultipleSearch`코드를 리팩토링했습니다. 기존에는 배열 형태로 리턴했지만 인자로 `queryName`에 해당하는 값 배열, `queryName`에 들어갈 배열을 받아 이를 `[queryName, queryValue]`형태에서 `{ queryName: queryValue }` 형태로 바꾸는 작업을 통해 `typescript`의 장점을 살리고 아래에서 비구조화 할당으로 사용하여 코드 라인을 줄일 수 있었습니다. 또한, `getServerSideProps`도 마찬가지로 이와 같은 방식을 사용하여 하드코딩 이슈를 없앴습니다.

## 📖 참고 사항

https://user-images.githubusercontent.com/62797441/193791163-228b2176-f586-48aa-ba53-4063f9747b9f.mov



