### PR TITLE
[feat] 상품 디테일 UI 추가하기

### DIFF
--- a/api/category/index.ts
+++ b/api/category/index.ts
@@ -1,21 +1,17 @@
-import { useQuery } from '@tanstack/react-query';
 import { Axios } from 'api/core';
-
 import {
   findChildrenByProp,
   findNameByProp,
-} from '../components/Upload/organisms/Dialog/utils';
+} from 'components/Upload/organisms/Dialog/utils';
 
-export const getCategoryData = async (): Promise<res.CategoryTree> => {
+export const getCategory = async (): Promise<res.CategoryTree> => {
   const response = await Axios.get('/api/category/v3');
   return response;
 };
 
-export const useCategoryTree = () => {
-  const response = useQuery(['category'], () => getCategoryData(), {
-    suspense: true,
-  });
-  return response.data;
+export const getExcludeCategory = async (): Promise<res.CategoryTree> => {
+  const response = await Axios.get('/api/category/exclude');
+  return response;
 };
 
 export const getCategoryTree = (

--- a/api/core/index.ts
+++ b/api/core/index.ts
@@ -37,7 +37,7 @@ const AiAxios = axios.create({
 function AuthErrorInterceptor(err: AxiosError): AxiosError {
   if (isAxiosError<res.error>(err) && err.response) {
     const {
-      data: { status },
+      data: { status, message },
     } = err.response;
     if (status === 404) {
       throw new NotFoundError(status);
@@ -47,6 +47,9 @@ function AuthErrorInterceptor(err: AxiosError): AxiosError {
     }
     if (status === 401) {
       throw new AuthError(status);
+    }
+    if (status === 400 && message === '해당 상품이 존재하지 않습니다') {
+      throw new NotFoundError(status);
     }
   }
 

--- a/api/product/index.ts
+++ b/api/product/index.ts
@@ -11,3 +11,8 @@ export const deleteProductDetail = async (id: string) => {
   const response = await Axios.delete(`/api/product/delete/${id}`);
   return response;
 };
+
+export const updateProductDetail = async (id: string) => {
+  const response = await Axios.put(`/api/product/${id}`);
+  return response;
+};

--- a/api/product/index.ts
+++ b/api/product/index.ts
@@ -1,4 +1,3 @@
-import { useQuery } from '@tanstack/react-query';
 import { Axios } from 'api/core';
 
 export const getProductDetail = async (
@@ -8,7 +7,7 @@ export const getProductDetail = async (
   return response;
 };
 
-export function useProdutDetail(id: string) {
-  const response = useQuery(['product', id], () => getProductDetail(id));
+export const deleteProductDetail = async (id: string) => {
+  const response = await Axios.delete(`/api/product/delete/${id}`);
   return response;
-}
+};

--- a/components/Product/organisms/ProductImgSlide/index.tsx
+++ b/components/Product/organisms/ProductImgSlide/index.tsx
@@ -1,0 +1,49 @@
+import { useCallback } from 'react';
+
+import { ImgProps } from '#types/index';
+import ImgSlideTools from '@molecules/ImgSlideTools';
+import ImgSlide from '@organisms/ImgSlide';
+import { useDeleteProduct } from 'hooks/api/product';
+import { toastError } from 'utils/toaster';
+
+type Props = {
+  id: string;
+  isMe: boolean;
+  imgList: (ImgProps | string)[];
+};
+
+function ProductImgSlide(slideProps: Props) {
+  const { id, isMe, imgList } = slideProps;
+  const { mutate } = useDeleteProduct(id);
+  const deleteProduct = useCallback(() => mutate(id), [id, mutate]);
+  const updateDate = useCallback(
+    () => toastError({ message: '준비중입니다.' }),
+    [],
+  );
+  const updateProduct = useCallback(
+    () => toastError({ message: '준비중입니다.' }),
+    [],
+  );
+  const report = useCallback(
+    () => toastError({ message: '준비중입니다.' }),
+    [],
+  );
+
+  const myMoreMenu = [
+    { name: '끌어올리기', onClick: updateDate },
+    { name: '수정하기', onClick: updateProduct },
+    { name: '삭제하기', onClick: deleteProduct },
+  ];
+
+  const notMyMoreMenu = [{ name: '신고하기', onClick: report }];
+
+  const options = isMe ? myMoreMenu : notMyMoreMenu;
+
+  return (
+    <ImgSlide imgList={imgList}>
+      <ImgSlideTools options={options} />
+    </ImgSlide>
+  );
+}
+
+export default ProductImgSlide;

--- a/components/Product/organisms/ProductImgSlide/index.tsx
+++ b/components/Product/organisms/ProductImgSlide/index.tsx
@@ -9,11 +9,12 @@ import { toastError } from 'utils/toaster';
 type Props = {
   id: string;
   isMe: boolean;
+  status: res.ProductStatus;
   imgList: (ImgProps | string)[];
 };
 
 function ProductImgSlide(slideProps: Props) {
-  const { id, isMe, imgList } = slideProps;
+  const { id, isMe, imgList, status } = slideProps;
   const { mutate } = useDeleteProduct(id);
   const deleteProduct = useCallback(() => mutate(id), [id, mutate]);
   const updateDate = useCallback(
@@ -40,7 +41,7 @@ function ProductImgSlide(slideProps: Props) {
   const options = isMe ? myMoreMenu : notMyMoreMenu;
 
   return (
-    <ImgSlide imgList={imgList}>
+    <ImgSlide {...{ status }} imgList={imgList}>
       <ImgSlideTools options={options} />
     </ImgSlide>
   );

--- a/components/Shop/molecules/ProductItem/index.tsx
+++ b/components/Shop/molecules/ProductItem/index.tsx
@@ -3,11 +3,11 @@ import Link from 'next/link';
 import { memo } from 'react';
 
 import { StyleProps } from '#types/props';
-import BorderBox from '@atoms/BorderBox';
 import ResponsiveImg from '@atoms/ResponsiveImg';
 import Span from '@atoms/Span';
 import { useTimeForToday } from 'hooks';
 
+import SoldoutBox from '../SoldoutBox';
 import $ from './style.module.scss';
 
 type Props = res.ProductSummary & StyleProps;
@@ -26,13 +26,7 @@ function ProductItem(itemProps: Props) {
           alt={title}
           className={$['product-img']}
         >
-          {isSoldOut && (
-            <BorderBox borderRadius="5px" className={$['soldout-box']}>
-              <Span fontSize={12} color="#fff">
-                sold out
-              </Span>
-            </BorderBox>
-          )}
+          <SoldoutBox {...{ isSoldOut }} />
         </ResponsiveImg>
 
         <div className={$['text-box']}>

--- a/components/Shop/molecules/ProductItem/style.module.scss
+++ b/components/Shop/molecules/ProductItem/style.module.scss
@@ -24,17 +24,6 @@
     }
   }
 
-  .soldout-box {
-    position: absolute;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background-color: rgba(0, 0, 0, 0.6);
-  }
-
   .text-box {
     overflow: hidden;
     width: 100%;

--- a/components/Shop/molecules/SoldoutBox/index.tsx
+++ b/components/Shop/molecules/SoldoutBox/index.tsx
@@ -1,0 +1,27 @@
+import { memo } from 'react';
+
+import BorderBox from '@atoms/BorderBox';
+import Span from '@atoms/Span';
+
+import $ from './style.module.scss';
+
+type Props = {
+  isSoldOut: boolean;
+};
+
+function SoldoutBox(itemProps: Props) {
+  const { isSoldOut } = itemProps;
+
+  if (isSoldOut) {
+    return (
+      <BorderBox borderRadius="5px" className={$['soldout-box']}>
+        <Span fontSize={12} color="#fff">
+          sold out
+        </Span>
+      </BorderBox>
+    );
+  }
+  return null;
+}
+
+export default memo(SoldoutBox);

--- a/components/Shop/molecules/SoldoutBox/style.module.scss
+++ b/components/Shop/molecules/SoldoutBox/style.module.scss
@@ -1,0 +1,10 @@
+.soldout-box {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.6);
+}

--- a/components/Upload/organisms/Basic/index.tsx
+++ b/components/Upload/organisms/Basic/index.tsx
@@ -6,7 +6,7 @@ import ErrorMsg from '@atoms/ErrorMsg';
 import { SelectArrow } from '@atoms/icon';
 import TextInput from '@atoms/TextInput';
 import InfoArticle from '@molecules/InfoArticle';
-import { getCategoryTree } from 'api/getCategoryData';
+import { getCategoryTree } from 'api/category';
 import useDebounceInput from 'hooks/useDebounceInput';
 
 import Dialog from '../Dialog';

--- a/components/shared/molecules/DropDown/index.tsx
+++ b/components/shared/molecules/DropDown/index.tsx
@@ -9,10 +9,9 @@ import classnames from 'classnames';
 import $ from './style.module.scss';
 
 type Props = {
-  options: (string | DefaultData)[];
+  options: (string | Partial<DefaultData>)[];
   children: React.ReactNode;
   name: string;
-  onClick?: (value: string) => void;
   top?: string;
   right?: string;
   bottom?: string;
@@ -22,7 +21,7 @@ type Props = {
 } & StyleProps;
 
 function DropDown(selectProps: Props) {
-  const { options, onClick, children, className } = selectProps;
+  const { options, children, className } = selectProps;
   const { name, fontWeight, fontSize, top, right, bottom, left } = selectProps;
   const labelRef = useRef<HTMLButtonElement>(null);
   const [isClicked, setIsClicked] = useSelect(labelRef);
@@ -34,10 +33,8 @@ function DropDown(selectProps: Props) {
     setIsClicked((clicked) => !clicked);
   };
 
-  const handleDropdownItem = (option?: string) => {
-    if (option && onClick) {
-      onClick(option);
-    }
+  const handleDropdownItem = (onClick?: () => void) => {
+    if (onClick) onClick();
     setIsClicked(false);
   };
 
@@ -68,7 +65,7 @@ function DropDown(selectProps: Props) {
           {options.map((option) => {
             const isObject = typeof option === 'object';
             const optionName = isObject ? option.name : option;
-            const optionData = isObject ? option.code : option;
+            const optionClick = isObject ? option.onClick : undefined;
 
             return (
               <li
@@ -80,9 +77,9 @@ function DropDown(selectProps: Props) {
                   $['dropdown-menu-hover'],
                 )}
                 onClick={() => {
-                  handleDropdownItem(optionData);
+                  handleDropdownItem(optionClick);
                 }}
-                onKeyPress={() => handleDropdownItem(optionData)}
+                onKeyPress={() => handleDropdownItem(optionClick)}
               >
                 <Span fontSize={fontSize || 12} {...{ fontWeight }}>
                   {optionName}

--- a/components/shared/molecules/DropDown/index.tsx
+++ b/components/shared/molecules/DropDown/index.tsx
@@ -1,0 +1,99 @@
+import { memo, useRef } from 'react';
+
+import { DefaultData } from '#types/index';
+import { StyleProps } from '#types/props';
+import Span from '@atoms/Span';
+import useSelect from '@molecules/SelectBox/useSelect';
+import classnames from 'classnames';
+
+import $ from './style.module.scss';
+
+type Props = {
+  options: (string | DefaultData)[];
+  children: React.ReactNode;
+  name: string;
+  onClick?: (value: string) => void;
+  top?: string;
+  right?: string;
+  bottom?: string;
+  left?: string;
+  fontWeight?: number;
+  fontSize?: number;
+} & StyleProps;
+
+function DropDown(selectProps: Props) {
+  const { options, onClick, children, className } = selectProps;
+  const { name, fontWeight, fontSize, top, right, bottom, left } = selectProps;
+  const labelRef = useRef<HTMLButtonElement>(null);
+  const [isClicked, setIsClicked] = useSelect(labelRef);
+
+  const handleMouseDown = (
+    e: React.MouseEvent<HTMLElement> | React.TouchEvent<HTMLElement>,
+  ) => {
+    e.preventDefault();
+    setIsClicked((clicked) => !clicked);
+  };
+
+  const handleDropdownItem = (option?: string) => {
+    if (option && onClick) {
+      onClick(option);
+    }
+    setIsClicked(false);
+  };
+
+  return (
+    <div className={classnames(className, $['dropdown-btn'])}>
+      <button
+        {...{ className }}
+        id={`${name}-select-box`}
+        ref={labelRef}
+        type="button"
+        aria-haspopup="true"
+        aria-expanded="true"
+        aria-controls={`${name}-dropdown-list`}
+        onClick={handleMouseDown}
+      >
+        {children}
+      </button>
+
+      {isClicked && (
+        <ul
+          id={`${name}-dropdown-list`}
+          aria-labelledby={`${name}-select-box`}
+          role="menu"
+          tabIndex={0}
+          className={$['dropdown-menulist']}
+          style={{ top, right, bottom, left }}
+        >
+          {options.map((option) => {
+            const isObject = typeof option === 'object';
+            const optionName = isObject ? option.name : option;
+            const optionData = isObject ? option.code : option;
+
+            return (
+              <li
+                tabIndex={0}
+                role="menuitem"
+                key={optionName}
+                className={classnames(
+                  $['dropdown-menu'],
+                  $['dropdown-menu-hover'],
+                )}
+                onClick={() => {
+                  handleDropdownItem(optionData);
+                }}
+                onKeyPress={() => handleDropdownItem(optionData)}
+              >
+                <Span fontSize={fontSize || 12} {...{ fontWeight }}>
+                  {optionName}
+                </Span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default memo(DropDown);

--- a/components/shared/molecules/DropDown/style.module.scss
+++ b/components/shared/molecules/DropDown/style.module.scss
@@ -1,0 +1,32 @@
+.dropdown-btn {
+  position: relative;
+}
+
+.dropdown-menulist {
+  z-index: 10;
+  position: absolute;
+  width: 100%;
+  min-width: 100px;
+  @include border(border, 5px, $gray-280);
+  background-color: $white;
+
+  .dropdown-menu {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 9px;
+    border-bottom: 1px solid $gray-280;
+    white-space: nowrap;
+    cursor: pointer;
+    &:last-child {
+      border: 0;
+    }
+
+    &-hover {
+      &:hover {
+        background-color: $clicked-background;
+        font-weight: 600;
+      }
+    }
+  }
+}

--- a/components/shared/molecules/ImgSlideTools/index.tsx
+++ b/components/shared/molecules/ImgSlideTools/index.tsx
@@ -1,16 +1,28 @@
 import { memo } from 'react';
 
+import { DefaultData } from '#types/index';
 import BackBtn from '@atoms/BackBtn';
 import { More } from '@atoms/icon';
-import classnames from 'classnames';
+import DropDown from '@molecules/DropDown';
 
 import $ from './style.module.scss';
 
-function ImgSlideTools() {
+type Props = {
+  options: Partial<DefaultData>[];
+};
+
+function ImgSlideTools({ options }: Props) {
   return (
     <div className={$['header-box']}>
       <BackBtn className={$.btn} />
-      <More className={classnames($.btn, $.more)} />
+      <DropDown
+        className={$.more}
+        options={options}
+        name="see-more"
+        right="32px"
+      >
+        <More className={$.btn} />
+      </DropDown>
     </div>
   );
 }

--- a/components/shared/organisms/ImgSlide/index.tsx
+++ b/components/shared/organisms/ImgSlide/index.tsx
@@ -1,26 +1,31 @@
 import Image from 'next/image';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { ImgProps } from '#types/index';
 import type { DefaultProps } from '#types/props';
 import InfoPageNum from '@molecules/InfoPageNum';
 import classnames from 'classnames';
+import SoldoutBox from 'components/Shop/molecules/SoldoutBox';
 import useDragScroll from 'hooks/useDragScroll';
 
 import $ from './style.module.scss';
 
 type Props = {
   imgList: (ImgProps | string)[];
+  status?: res.ProductStatus;
 } & DefaultProps;
 
 export default function ImgSlide(slideProps: Props) {
-  const { children, className, style, imgList } = slideProps;
+  const { children, className, style, imgList, status } = slideProps;
   const [imgCurrentNo, setImgCurrentNo] = useState(0);
   const [mouseDownClientX, setMouseDownClientX] = useState(0);
   const [mouseUpClientX, setMouseUpClientX] = useState(0);
   const dragRef = useRef<HTMLDivElement>(null);
   const ref = dragRef.current;
+  const isSoldOut = status === 'soldout';
+  const currentImgNo = imgCurrentNo + 1;
+  const imgListLen = imgList.length;
   useDragScroll(dragRef);
 
   const onChangeImg = useCallback(
@@ -45,27 +50,47 @@ export default function ImgSlide(slideProps: Props) {
 
   const onMouseTouchDown = (num: number) => setMouseDownClientX(num);
   const onMouseTouchUp = (num: number) => setMouseUpClientX(num);
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.keyCode === 37) {
+      onChangeImg(imgCurrentNo - 1);
+      return;
+    }
+    if (e.keyCode === 39) onChangeImg(imgCurrentNo + 1);
+  };
 
   return (
     <section className={$['slide-box']}>
       {children}
 
-      <article className={$.slider} ref={dragRef} style={style}>
+      <div
+        tabIndex={0}
+        role="slider"
+        aria-valuenow={currentImgNo}
+        aria-valuemin={1}
+        aria-valuemax={imgListLen}
+        aria-roledescription="carousel"
+        aria-label="이미지 슬라이드를 방향키로 움직일 수 있습니다."
+        aria-orientation="horizontal"
+        className={$.slider}
+        ref={dragRef}
+        style={style}
+        onTouchStart={(e: React.TouchEvent) =>
+          onMouseTouchDown(e.changedTouches[0].pageX)
+        }
+        onTouchEnd={(e: React.TouchEvent) =>
+          onMouseTouchUp(e.changedTouches[0].pageX)
+        }
+        onMouseDown={(e: React.MouseEvent) => onMouseTouchDown(e.clientX)}
+        onMouseUp={(e: React.MouseEvent) => onMouseTouchUp(e.clientX)}
+        onKeyDown={onKeyDown}
+      >
         <ul
-          role="presentation"
+          role="region"
           className={classnames($['slide-list'], className)}
           style={{
             transform: `translateX(
                 ${ref && -ref.clientWidth * imgCurrentNo + ref.scrollLeft}px)`,
           }}
-          onTouchStart={(e: React.TouchEvent) =>
-            onMouseTouchDown(e.changedTouches[0].pageX)
-          }
-          onTouchEnd={(e: React.TouchEvent) =>
-            onMouseTouchUp(e.changedTouches[0].pageX)
-          }
-          onMouseDown={(e: React.MouseEvent) => onMouseTouchDown(e.clientX)}
-          onMouseUp={(e: React.MouseEvent) => onMouseTouchUp(e.clientX)}
         >
           {imgList.map((img, idx) => {
             const key =
@@ -73,17 +98,24 @@ export default function ImgSlide(slideProps: Props) {
             const src = typeof img !== 'string' ? img.src : img;
             const alt = typeof img !== 'string' ? img.alt : `이미지${idx + 1}`;
             return (
-              <li key={key} className={$.slide}>
+              <li
+                key={key}
+                className={$.slide}
+                aria-roledescription="slide"
+                aria-label={`${imgListLen}개의 이미지 중 ${imgCurrentNo}번째 이미지`}
+              >
                 <Image {...{ src, alt }} layout="fill" priority />
               </li>
             );
           })}
         </ul>
-      </article>
 
-      <InfoPageNum className={$['page-num']}>{`${imgCurrentNo + 1}/${
-        imgList.length
-      }`}</InfoPageNum>
+        <SoldoutBox {...{ isSoldOut }} />
+      </div>
+
+      <InfoPageNum
+        className={$['page-num']}
+      >{`${currentImgNo}/${imgListLen}`}</InfoPageNum>
     </section>
   );
 }

--- a/components/shared/organisms/ImgSlide/index.tsx
+++ b/components/shared/organisms/ImgSlide/index.tsx
@@ -3,8 +3,7 @@ import Image from 'next/image';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { ImgProps } from '#types/index';
-import type { StyleProps } from '#types/props';
-import ImgSlideTools from '@molecules/ImgSlideTools';
+import type { DefaultProps } from '#types/props';
 import InfoPageNum from '@molecules/InfoPageNum';
 import classnames from 'classnames';
 import useDragScroll from 'hooks/useDragScroll';
@@ -13,9 +12,10 @@ import $ from './style.module.scss';
 
 type Props = {
   imgList: (ImgProps | string)[];
-} & StyleProps;
+} & DefaultProps;
 
-export default function ImgSlide({ className, style, imgList }: Props) {
+export default function ImgSlide(slideProps: Props) {
+  const { children, className, style, imgList } = slideProps;
   const [imgCurrentNo, setImgCurrentNo] = useState(0);
   const [mouseDownClientX, setMouseDownClientX] = useState(0);
   const [mouseUpClientX, setMouseUpClientX] = useState(0);
@@ -48,7 +48,7 @@ export default function ImgSlide({ className, style, imgList }: Props) {
 
   return (
     <section className={$['slide-box']}>
-      <ImgSlideTools />
+      {children}
 
       <article className={$.slider} ref={dragRef} style={style}>
         <ul

--- a/components/shared/organisms/ImgSlide/style.module.scss
+++ b/components/shared/organisms/ImgSlide/style.module.scss
@@ -6,6 +6,7 @@
     background-color: $gray-280;
     transition: height 0.15s ease-in;
     .slide-list {
+      position: relative;
       display: flex;
       transition: all 0.35s ease-in-out;
       .slide {

--- a/components/shared/templates/Layout/index.tsx
+++ b/components/shared/templates/Layout/index.tsx
@@ -1,26 +1,24 @@
 import { ReactNode } from 'react';
 
+import { StyleProps } from '#types/props';
 import classnames from 'classnames';
 
 import $ from './style.module.scss';
 
-interface Props {
+type Props = {
   noPadding?: boolean;
   children: ReactNode;
-  decreaseHeight?: number;
-}
+} & StyleProps;
 
 export default function PageLayout(layoutProps: Props) {
   const { noPadding } = layoutProps;
-  const { children } = layoutProps;
-  const { decreaseHeight = 0 } = layoutProps;
+  const { children, className } = layoutProps;
 
   return (
     <main
-      className={classnames($.layout, { [$['no-padding']]: noPadding })}
-      style={{
-        paddingBottom: `${noPadding ? 0 : 30 + decreaseHeight}px`,
-      }}
+      className={classnames($.layout, className, {
+        [$['no-padding']]: noPadding,
+      })}
     >
       {children}
     </main>

--- a/constants/react-query/index.ts
+++ b/constants/react-query/index.ts
@@ -2,4 +2,7 @@ export const queryKey = {
   productItemList: (requestParams: Omit<req.ShopFeed, 'page' | 'size'>) => {
     return ['productItemList', { ...requestParams }];
   },
+  productDetail: (id: string) => {
+    return ['product', id];
+  },
 };

--- a/constants/react-query/index.ts
+++ b/constants/react-query/index.ts
@@ -1,4 +1,7 @@
 export const queryKey = {
+  category: (isExcluded: boolean) => {
+    return [isExcluded ? 'excludedCategory' : 'category'];
+  },
   productItemList: (requestParams: Omit<req.ShopFeed, 'page' | 'size'>) => {
     return ['productItemList', { ...requestParams }];
   },

--- a/hooks/api/category/index.ts
+++ b/hooks/api/category/index.ts
@@ -1,0 +1,15 @@
+import { queryKey } from '@constants/react-query';
+import { getCategory, getExcludeCategory } from 'api/category';
+
+import { useCoreQuery } from '../core';
+
+export const useCategoryTree = (isExcluded: boolean) => {
+  const response = useCoreQuery(
+    queryKey.category(isExcluded),
+    () => (isExcluded ? getExcludeCategory() : getCategory()),
+    {
+      suspense: true,
+    },
+  );
+  return response.data;
+};

--- a/hooks/api/product/index.ts
+++ b/hooks/api/product/index.ts
@@ -1,6 +1,10 @@
 import { queryKey } from '@constants/react-query';
 import { isAxiosError } from 'api/core';
-import { deleteProductDetail, getProductDetail } from 'api/product';
+import {
+  deleteProductDetail,
+  getProductDetail,
+  updateProductDetail,
+} from 'api/product';
 import { queryClient } from 'pages/_app';
 import { toastError, toastSuccess } from 'utils/toaster';
 
@@ -19,6 +23,23 @@ export function useDeleteProduct(id: string) {
       queryClient.removeQueries(queryKey.productDetail(id));
       queryClient.invalidateQueries(['productItemList']);
       toastSuccess({ message: '상품을 삭제했습니다.' });
+    },
+    onError: (err) => {
+      if (isAxiosError<res.ProductDeleteError>(err) && !!err.response) {
+        const { message } = err.response.data;
+        toastError({ message });
+      }
+    },
+  });
+  return response;
+}
+
+export function useUpdateProduct(id: string) {
+  const response = useCoreMutation(updateProductDetail, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(queryKey.productDetail(id));
+      queryClient.invalidateQueries(['productItemList']);
+      toastSuccess({ message: '상품을 수정했습니다.' });
     },
     onError: (err) => {
       if (isAxiosError<res.ProductDeleteError>(err) && !!err.response) {

--- a/hooks/api/product/index.ts
+++ b/hooks/api/product/index.ts
@@ -1,0 +1,31 @@
+import { queryKey } from '@constants/react-query';
+import { isAxiosError } from 'api/core';
+import { deleteProductDetail, getProductDetail } from 'api/product';
+import { queryClient } from 'pages/_app';
+import { toastError, toastSuccess } from 'utils/toaster';
+
+import { useCoreMutation, useCoreQuery } from '../core';
+
+export function useProdutDetail(id: string) {
+  const response = useCoreQuery(queryKey.productDetail(id), () =>
+    getProductDetail(id),
+  );
+  return response;
+}
+
+export function useDeleteProduct(id: string) {
+  const response = useCoreMutation(deleteProductDetail, {
+    onSuccess: () => {
+      queryClient.removeQueries(queryKey.productDetail(id));
+      queryClient.invalidateQueries(['productItemList']);
+      toastSuccess({ message: '상품을 삭제했습니다.' });
+    },
+    onError: (err) => {
+      if (isAxiosError<res.ProductDeleteError>(err) && !!err.response) {
+        const { message } = err.response.data;
+        toastError({ message });
+      }
+    },
+  });
+  return response;
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -26,23 +26,21 @@ type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout;
 };
 
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 3 * 60 * 1000,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
 function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   const router = useRouter();
   const isMount = useMounted();
   const [_, height] = useWindowResize();
-  const [queryClient] = React.useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            staleTime: 3 * 60 * 1000,
-            refetchOnMount: false,
-            refetchOnReconnect: false,
-            refetchOnWindowFocus: false,
-          },
-        },
-      }),
-  );
   const getLayout = Component.getLayout || ((page) => page);
 
   const setScreenSize = () => {

--- a/pages/info/basic/index.tsx
+++ b/pages/info/basic/index.tsx
@@ -159,7 +159,7 @@ export function BasicInfo() {
 }
 
 BasicInfo.getLayout = function getLayout(page: ReactElement) {
-  return <Layout decreaseHeight={80}>{page}</Layout>;
+  return <Layout className={$['basic-info-layout']}>{page}</Layout>;
 };
 
 export default BasicInfo;

--- a/pages/info/basic/style.module.scss
+++ b/pages/info/basic/style.module.scss
@@ -1,3 +1,7 @@
+.basic-info-layout {
+  padding-bottom: 80px;
+}
+
 .height-input {
   @include tablet() {
     width: 50%;

--- a/pages/info/color/index.tsx
+++ b/pages/info/color/index.tsx
@@ -4,6 +4,7 @@ import { ReactElement, useCallback, useEffect } from 'react';
 
 import ButtonFooter from '@atoms/ButtonFooter';
 import HeadMeta from '@atoms/HeadMeta';
+import { colorBtnProps } from '@constants/colorInfo/constants';
 import { seoData } from '@constants/seo';
 import InfoHeader from '@molecules/InfoHeader';
 import InfoPageNum from '@molecules/InfoPageNum';
@@ -14,7 +15,7 @@ import { getStaticData, useStaticData } from 'api/getStaticData';
 import { usePostPreference } from 'api/preference';
 import { useInfoStore } from 'store/useInfoStore';
 
-import { colorBtnProps } from '../../../constants/colorInfo/constants';
+import $ from './style.module.scss';
 
 export async function getStaticProps() {
   const queryClient = new QueryClient();
@@ -84,7 +85,7 @@ export function ColorInfo() {
 }
 
 ColorInfo.getLayout = function getLayout(page: ReactElement) {
-  return <Layout decreaseHeight={80}>{page}</Layout>;
+  return <Layout className={$['color-info-layout']}>{page}</Layout>;
 };
 
 export default ColorInfo;

--- a/pages/info/color/style.module.scss
+++ b/pages/info/color/style.module.scss
@@ -1,0 +1,3 @@
+.color-info-layout {
+  padding-bottom: 80px;
+}

--- a/pages/info/style/index.tsx
+++ b/pages/info/style/index.tsx
@@ -97,7 +97,7 @@ export function StyleInfo() {
 }
 
 StyleInfo.getLayout = function getLayout(page: ReactElement) {
-  return <Layout decreaseHeight={80}>{page}</Layout>;
+  return <Layout className={$['style-info-layout']}>{page}</Layout>;
 };
 
 export default StyleInfo;

--- a/pages/info/style/style.module.scss
+++ b/pages/info/style/style.module.scss
@@ -1,3 +1,7 @@
+.style-info-layout {
+  padding-bottom: 80px;
+}
+
 .style-info {
   display: grid;
   grid-template-rows: auto;

--- a/pages/shop/[id]/index.tsx
+++ b/pages/shop/[id]/index.tsx
@@ -48,7 +48,8 @@ function ShopDetail({ id }: { id: string }) {
     const { isMe, sellerInfo, basic, sellerNotice, measure } = detailData;
     const { opinion, price, isIncludeDelivery, updatedAt, like, views } =
       detailData;
-    addProduct({ id: +id, img: sellerInfo.image[0] }); // TODO: 실험해볼 것
+    const status = 'soldout'; // TODO: 백엔드와 협의
+    addProduct({ id: +id, img: sellerInfo.image[0] });
     return (
       <>
         <HeadMeta
@@ -57,7 +58,9 @@ function ShopDetail({ id }: { id: string }) {
         />
 
         <Layout noPadding className={$['shop-detail-layout']}>
-          <ProductImgSlide {...{ id, isMe, imgList: sellerInfo.image }} />
+          <ProductImgSlide
+            {...{ id, isMe, status, imgList: sellerInfo.image }}
+          />
           <Profile profile={sellerInfo} />
           <section className={$['shop-detail-info']}>
             <ProductBasic basic={basic} />

--- a/pages/shop/[id]/index.tsx
+++ b/pages/shop/[id]/index.tsx
@@ -9,6 +9,7 @@ import ImgSlide from '@organisms/ImgSlide';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';
 import NotFound from '@templates/NotFound';
+import { withGetServerSideProps } from 'api/core/withGetServerSideProps';
 import { getProductDetail, useProdutDetail } from 'api/product';
 import SellerComment from 'components/Product/molecules/SellerComment';
 import ProductBasic from 'components/Product/organisms/ProductBasic';
@@ -19,22 +20,22 @@ import { useSearchStore } from 'store/useSearchStore';
 
 import $ from './style.module.scss';
 
-export async function getServerSideProps({
-  params,
-}: GetServerSidePropsContext) {
-  const queryClient = new QueryClient();
-  const id = params?.id;
-  const paramId = (typeof id !== 'object' && id) || '0';
+export const getServerSideProps = withGetServerSideProps(
+  async ({ params }: GetServerSidePropsContext) => {
+    const queryClient = new QueryClient();
+    const id = params?.id;
+    const paramId = (typeof id !== 'object' && id) || '0';
 
-  await queryClient.prefetchQuery(['styles'], () => getProductDetail(paramId));
+    await queryClient.fetchQuery(['styles'], () => getProductDetail(paramId));
 
-  return {
-    props: {
-      dehydratedState: dehydrate(queryClient),
-      id: paramId,
-    },
-  };
-}
+    return {
+      props: {
+        dehydratedState: dehydrate(queryClient),
+        id: paramId,
+      },
+    };
+  },
+);
 
 function ShopDetail({ id }: { id: string }) {
   const { data } = useProdutDetail(id);
@@ -55,7 +56,7 @@ function ShopDetail({ id }: { id: string }) {
           url={`${seoData.url}/shop/${id}`}
         />
 
-        <Layout noPadding decreaseHeight={100}>
+        <Layout noPadding className={$['shop-detail-layout']}>
           <ImgSlide imgList={sellerInfo.image} />
           <Profile profile={sellerInfo} />
           <section className={$['shop-detail-info']}>
@@ -79,7 +80,7 @@ function ShopDetail({ id }: { id: string }) {
       </>
     );
   }
-  return <NotFound />; // TODO: 데이터 fetching 실패했을 때, 로딩, 에러
+  return null;
 }
 
 export default ShopDetail;

--- a/pages/shop/[id]/index.tsx
+++ b/pages/shop/[id]/index.tsx
@@ -5,16 +5,17 @@ import { useCallback } from 'react';
 import HeadMeta from '@atoms/HeadMeta';
 import { seoData } from '@constants/seo';
 import Profile from '@molecules/Profile';
-import ImgSlide from '@organisms/ImgSlide';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';
 import { withGetServerSideProps } from 'api/core/withGetServerSideProps';
-import { getProductDetail, useProdutDetail } from 'api/product';
+import { getProductDetail } from 'api/product';
 import SellerComment from 'components/Product/molecules/SellerComment';
 import ProductBasic from 'components/Product/organisms/ProductBasic';
 import ProductFooter from 'components/Product/organisms/ProductFooter';
+import ProductImgSlide from 'components/Product/organisms/ProductImgSlide';
 import ProductNotice from 'components/Product/organisms/ProductNotice';
 import ProductSize from 'components/Product/organisms/ProductSize';
+import { useProdutDetail } from 'hooks/api/product';
 import { useSearchStore } from 'store/useSearchStore';
 
 import $ from './style.module.scss';
@@ -56,7 +57,7 @@ function ShopDetail({ id }: { id: string }) {
         />
 
         <Layout noPadding className={$['shop-detail-layout']}>
-          <ImgSlide imgList={sellerInfo.image} />
+          <ProductImgSlide {...{ id, isMe, imgList: sellerInfo.image }} />
           <Profile profile={sellerInfo} />
           <section className={$['shop-detail-info']}>
             <ProductBasic basic={basic} />

--- a/pages/shop/[id]/index.tsx
+++ b/pages/shop/[id]/index.tsx
@@ -8,7 +8,6 @@ import Profile from '@molecules/Profile';
 import ImgSlide from '@organisms/ImgSlide';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';
-import NotFound from '@templates/NotFound';
 import { withGetServerSideProps } from 'api/core/withGetServerSideProps';
 import { getProductDetail, useProdutDetail } from 'api/product';
 import SellerComment from 'components/Product/molecules/SellerComment';

--- a/pages/shop/[id]/style.module.scss
+++ b/pages/shop/[id]/style.module.scss
@@ -1,3 +1,7 @@
+.shop-detail-layout {
+  padding-bottom: 100px;
+}
+
 .shop-detail-info {
   padding: 16px 23px 20px;
 }

--- a/pages/shop/index.tsx
+++ b/pages/shop/index.tsx
@@ -10,12 +10,8 @@ import { seoData } from '@constants/seo';
 import Footer from '@organisms/Footer';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';
+import { getCategory, getCategoryTree } from 'api/category';
 import { withGetServerSideProps } from 'api/core/withGetServerSideProps';
-import {
-  getCategoryData,
-  useCategoryTree,
-  getCategoryTree,
-} from 'api/getCategoryData';
 import { getInfiniteProducts } from 'api/shop';
 import ProductItemList from 'components/Shop/Organisms/ProductItemList';
 import ShopHeader from 'components/Shop/Organisms/ShopHeader';
@@ -24,6 +20,7 @@ import {
   curCategoryChildrenByProp,
 } from 'components/Upload/organisms/Dialog/utils';
 import { useMultipleSearch } from 'hooks';
+import { useCategoryTree } from 'hooks/api/category';
 import { getQueryStringObj, getQueriesArr } from 'utils';
 
 export const getServerSideProps = withGetServerSideProps(
@@ -39,7 +36,7 @@ export const getServerSideProps = withGetServerSideProps(
 
     const queryClient = new QueryClient();
 
-    await queryClient.fetchQuery(['category'], () => getCategoryData());
+    await queryClient.fetchQuery(queryKey.category(false), () => getCategory());
     await queryClient.fetchInfiniteQuery(
       queryKey.productItemList(queryStringObj),
       getInfiniteProducts(queryStringObj),
@@ -59,7 +56,7 @@ export const getServerSideProps = withGetServerSideProps(
 );
 
 function Shop() {
-  const data = useCategoryTree()?.data;
+  const data = useCategoryTree(false)?.data;
   const queryObj = useMultipleSearch(queryData, queries);
   const { category, hide_sold, order } = queryObj;
 

--- a/pages/upload/index.tsx
+++ b/pages/upload/index.tsx
@@ -6,10 +6,12 @@ import BackBtn from '@atoms/BackBtn';
 import ButtonFooter from '@atoms/ButtonFooter';
 import HeadMeta from '@atoms/HeadMeta';
 import { queryKey } from '@constants/react-query';
+import { additionData, styleData } from '@constants/upload/constants';
+import { reviewData, sizeData } from '@constants/upload/utils';
 import PageHeader from '@molecules/PageHeader';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';
-import { getExcludeCategory } from 'api/category';
+import { getCategory } from 'api/category';
 import { withGetServerSideProps } from 'api/core/withGetServerSideProps';
 import { useProductUpload } from 'api/upload';
 import AdditionInfo from 'components/Upload/organisms/AdditionInfo';
@@ -29,15 +31,11 @@ import { arrToString, getJudgeCategory, getMeasureElement } from 'utils';
 import { toastError, toastSuccess } from 'utils/toaster';
 import { judgeValid } from 'utils/upload.utils';
 
-import { additionData, styleData } from '../../constants/upload/constants';
-import { reviewData, sizeData } from '../../constants/upload/utils';
 import $ from './style.module.scss';
 
 export const getStaticProps = withGetServerSideProps(async () => {
   const queryClient = new QueryClient();
-  await queryClient.fetchQuery(queryKey.category(true), () =>
-    getExcludeCategory(),
-  );
+  await queryClient.fetchQuery(queryKey.category(false), () => getCategory());
 
   return {
     props: {
@@ -48,7 +46,7 @@ export const getStaticProps = withGetServerSideProps(async () => {
 
 function Upload() {
   const router = useRouter();
-  const categoryData = useCategoryTree(true)?.data;
+  const categoryData = useCategoryTree(false)?.data;
   const states = useUploadStore((state) => state);
   const { price, isIncludeDelivery, style, basicInfo, size } = states;
   const { category } = basicInfo;

--- a/pages/upload/index.tsx
+++ b/pages/upload/index.tsx
@@ -5,10 +5,12 @@ import { ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
 import BackBtn from '@atoms/BackBtn';
 import ButtonFooter from '@atoms/ButtonFooter';
 import HeadMeta from '@atoms/HeadMeta';
+import { queryKey } from '@constants/react-query';
 import PageHeader from '@molecules/PageHeader';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';
-import { getCategoryData, useCategoryTree } from 'api/getCategoryData';
+import { getExcludeCategory } from 'api/category';
+import { withGetServerSideProps } from 'api/core/withGetServerSideProps';
 import { useProductUpload } from 'api/upload';
 import AdditionInfo from 'components/Upload/organisms/AdditionInfo';
 import Basic from 'components/Upload/organisms/Basic';
@@ -21,6 +23,7 @@ import SizeInfo from 'components/Upload/organisms/SizeInfo';
 import StyleSelect from 'components/Upload/organisms/StyleSelect';
 import { seoData } from 'constants/seo';
 import { useMounted, useDidMountEffect } from 'hooks';
+import { useCategoryTree } from 'hooks/api/category';
 import { useUploadStore } from 'store/useUploadStore';
 import { arrToString, getJudgeCategory, getMeasureElement } from 'utils';
 import { toastError, toastSuccess } from 'utils/toaster';
@@ -30,20 +33,22 @@ import { additionData, styleData } from '../../constants/upload/constants';
 import { reviewData, sizeData } from '../../constants/upload/utils';
 import $ from './style.module.scss';
 
-export async function getStaticProps() {
+export const getStaticProps = withGetServerSideProps(async () => {
   const queryClient = new QueryClient();
-  await queryClient.prefetchQuery(['category'], () => getCategoryData());
+  await queryClient.fetchQuery(queryKey.category(true), () =>
+    getExcludeCategory(),
+  );
 
   return {
     props: {
       dehydratedState: dehydrate(queryClient),
     },
   };
-}
+});
 
 function Upload() {
   const router = useRouter();
-  const categoryData = useCategoryTree()?.data;
+  const categoryData = useCategoryTree(true)?.data;
   const states = useUploadStore((state) => state);
   const { price, isIncludeDelivery, style, basicInfo, size } = states;
   const { category } = basicInfo;

--- a/types/apiTypes/product.d.ts
+++ b/types/apiTypes/product.d.ts
@@ -50,4 +50,5 @@ declare namespace res {
     errors: string[];
     code: string;
   };
+  type ProductStatus = 'soldout' | 'sale' | 'reserve';
 }

--- a/types/apiTypes/product.d.ts
+++ b/types/apiTypes/product.d.ts
@@ -44,4 +44,10 @@ declare namespace res {
       views: number;
     };
   };
+  type ProductDeleteError = {
+    message: string;
+    status: number;
+    errors: string[];
+    code: string;
+  };
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -9,7 +9,12 @@ export type ImgProps = {
   height?: number;
 } & ImgBasicProps;
 
-export type DefaultData = { id?: string; name: string; code: string };
+export type DefaultData = {
+  id?: string;
+  onClick?: () => void;
+  name: string;
+  code: string;
+};
 
 export type UrlQuery = string | string[] | undefined;
 


### PR DESCRIPTION
## 💡 이슈
resolve #110 

## 🤩 개요
상품 디테일 UI 추가하기

## 🧑‍💻 작업 사항

- [ ] 솔드아웃 UI 만들기
- [ ] 이미지 슬라이드 컴포넌트 리팩토링 및 웹 접근성 추가
- [ ] 드롭다운 컴포넌트 만들기 및 상품 디테일에 추가

## 📖 참고 사항
이 [자료](https://nuli.navercorp.com/community/article/1132993)를 참고하여 이미지 슬라이드의 웹 접근성을 높였습니다. 키보드 방향키로 이미지 슬라이드를 넘기는 기능과 총 몇 페이지 중 현재 페이지 숫자는 어디인지에 대한 웹 접근성을 높였습니다.

드롭다운 컴포넌트의 경우 SelectBox 컴포넌트의 코드를 기반으로 재구성했습니다. Select와는 다르게 선택하는 것이 아니라 해당 항목을 클릭하면 특정 항목의 이벤트가 발생하도록 하는 구조이며 UI가 달라 SelectBox와 구성은 비슷하지만 따로 구현했습니다.

https://user-images.githubusercontent.com/62797441/195062028-e8f75a0a-b078-4d21-8192-4e95f05a84c4.mov