### PR TITLE
[feat] 상품 QA, 연락하기 모달 추가 및 업로드에 static데이터 불러오기

### DIFF
--- a/__mocks__/shopDetail.ts
+++ b/__mocks__/shopDetail.ts
@@ -1,24 +1,17 @@
 export const shopDetail = {
   isMe: true,
+  contact: '010-6777-9169',
+  isSoldOut: false,
   sellerInfo: {
     profileImg:
       'https://images.unsplash.com/photo-1618588507085-c79565432917?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8YmVhdXRpZnVsJTIwbmF0dXJlfGVufDB8fDB8fA%3D%3D&w=1000&q=80',
     nickname: '사용자128',
+    image: [
+      'https://user-images.githubusercontent.com/62797441/180398288-76213583-0128-429e-bb1c-672a281e56dd.png',
+      'https://user-images.githubusercontent.com/62797441/180398288-76213583-0128-429e-bb1c-672a281e56dd.png',
+      'https://user-images.githubusercontent.com/62797441/180398288-76213583-0128-429e-bb1c-672a281e56dd.png',
+    ],
   },
-  image: [
-    {
-      src: 'https://user-images.githubusercontent.com/62797441/180398288-76213583-0128-429e-bb1c-672a281e56dd.png',
-      alt: '이미지12',
-    },
-    {
-      src: 'https://user-images.githubusercontent.com/62797441/180398288-76213583-0128-429e-bb1c-672a281e56dd.png',
-      alt: '이미지23',
-    },
-    {
-      src: 'https://user-images.githubusercontent.com/62797441/180398288-76213583-0128-429e-bb1c-672a281e56dd.png',
-      alt: '이미지34',
-    },
-  ],
   basic: {
     title: '스투시 프린팅 티셔츠',
     classification: '상의/탑',
@@ -31,7 +24,7 @@ export const shopDetail = {
     pollution: '외관상 안 보임',
     height: '170',
     length: '엉덩이',
-    bodyForm: '보통',
+    bodyShape: '보통',
     fit: '루즈',
     purchaseTime: '작년 9월',
     purchasePlace: '스투시 온라인 매장',

--- a/__mocks__/shopDetail.ts
+++ b/__mocks__/shopDetail.ts
@@ -1,6 +1,6 @@
 export const shopDetail = {
   isMe: true,
-  contact: '010-6777-9169',
+  contact: 'https://coding-factory.tistory.com/819',
   isSoldOut: false,
   sellerInfo: {
     profileImg:

--- a/src/api/core/errorInterceptor.ts
+++ b/src/api/core/errorInterceptor.ts
@@ -1,3 +1,4 @@
+import { USER_NOT_EXISTED } from '@constants/api';
 import { AxiosError } from 'axios';
 
 import {
@@ -10,7 +11,7 @@ import {
 export default function ErrorInterceptor(err: AxiosError): AxiosError {
   if (isAxiosError<res.error>(err) && err.response) {
     const {
-      data: { status, message },
+      data: { status, message, code },
     } = err.response;
     if (status === 404) {
       throw new NotFoundError(status, message);
@@ -20,6 +21,8 @@ export default function ErrorInterceptor(err: AxiosError): AxiosError {
       throw new AuthError(status, message);
     } else if (status === 400 && message === '해당 상품이 존재하지 않습니다') {
       throw new NotFoundError(status, message);
+    } else if (status === 400 && code === USER_NOT_EXISTED) {
+      throw new ForbiddenError(status, message);
     }
   }
 

--- a/src/components/Product/organisms/ProductFooter/index.tsx
+++ b/src/components/Product/organisms/ProductFooter/index.tsx
@@ -1,9 +1,12 @@
+import { useState } from 'react';
+
 import { ProductFooterInfo } from '#types/product';
 import type { DefaultProps } from '#types/props';
 import Button from '@atoms/Button';
 import { ClickHeart, SmallHeart, Time, Views } from '@atoms/icon';
 import IconText from '@atoms/IconText';
 import Span from '@atoms/Span';
+import DialogModal from '@templates/DialogModal';
 import classnames from 'classnames';
 import useTimeForToday from 'src/hooks/useTimeForToday';
 
@@ -13,14 +16,14 @@ type Props = {
   footer: ProductFooterInfo;
 } & DefaultProps;
 
-export default function ProductFooter({
-  className,
-  style,
-  children,
-  footer,
-}: Props) {
-  const { price, isIncludeDelivery, updatedAt, like, views } = footer;
+export default function ProductFooter(footerProps: Props) {
+  const { className, style, children, footer } = footerProps;
+  const { price, isIncludeDelivery, updatedAt, like, views, contact } = footer;
   const time = useTimeForToday(updatedAt);
+  const [isOpen, setIsOpen] = useState(false);
+  const openModal = () => setIsOpen(true);
+  const closeModal = () => setIsOpen(false);
+
   const iconData = [
     {
       Icon: Views,
@@ -69,7 +72,20 @@ export default function ProductFooter({
               className={$.price}
             >{`${price.toLocaleString()}원`}</Span>
           </div>
-          <Button className={$['product-btn']}>{children}</Button>
+          <Button className={$['product-btn']} onClick={openModal}>
+            {children}
+          </Button>
+
+          <DialogModal
+            id="contact-modal"
+            label="판매자에게 연락하기 모달"
+            isOpen={isOpen}
+            title="아래 정보를 통해 연락할 수 있습니다."
+            content="현재 채팅 기능 준비중이에요. 서비스 준비 전까지 조금만 기다려주세요."
+            emphasisContent={contact}
+            clickText="닫기"
+            onClick={closeModal}
+          />
         </div>
       </div>
     </footer>

--- a/src/components/Product/organisms/ProductImgSlide/index.tsx
+++ b/src/components/Product/organisms/ProductImgSlide/index.tsx
@@ -9,12 +9,12 @@ import { toastError } from 'src/utils/toaster';
 type Props = {
   id: string;
   isMe: boolean;
-  status: res.ProductStatus;
+  isSoldOut: boolean;
   imgList: (ImgProps | string)[];
 };
 
 function ProductImgSlide(slideProps: Props) {
-  const { id, isMe, imgList, status } = slideProps;
+  const { id, isMe, imgList, isSoldOut } = slideProps;
   const { mutate } = useDeleteProduct(id);
   const deleteProduct = useCallback(() => mutate(id), [id, mutate]);
   const updateDate = useCallback(
@@ -41,7 +41,7 @@ function ProductImgSlide(slideProps: Props) {
   const options = isMe ? myMoreMenu : notMyMoreMenu;
 
   return (
-    <ImgSlide {...{ status }} imgList={imgList}>
+    <ImgSlide {...{ isSoldOut }} imgList={imgList}>
       <ImgSlideTools options={options} />
     </ImgSlide>
   );

--- a/src/components/Product/organisms/ProductImgSlide/index.tsx
+++ b/src/components/Product/organisms/ProductImgSlide/index.tsx
@@ -1,3 +1,5 @@
+import { useRouter } from 'next/router';
+
 import { useCallback } from 'react';
 
 import { ImgProps } from '#types/index';
@@ -15,16 +17,17 @@ type Props = {
 
 function ProductImgSlide(slideProps: Props) {
   const { id, isMe, imgList, isSoldOut } = slideProps;
+  const router = useRouter();
   const { mutate } = useDeleteProduct(id);
+
   const deleteProduct = useCallback(() => mutate(id), [id, mutate]);
   const updateDate = useCallback(
     () => toastError({ message: '준비중입니다.' }),
     [],
   );
-  const updateProduct = useCallback(
-    () => toastError({ message: '준비중입니다.' }),
-    [],
-  );
+  const updateProduct = useCallback(() => {
+    router.push(`/upload/${id}`);
+  }, [id, router]);
   const report = useCallback(
     () => toastError({ message: '준비중입니다.' }),
     [],

--- a/src/components/shared/atoms/ImgBox/index.tsx
+++ b/src/components/shared/atoms/ImgBox/index.tsx
@@ -42,12 +42,13 @@ function ImgBox({
       style={{ ...style }}
       role="button"
       tabIndex={0}
-      onClick={() => {
-        if (id && isNeedClick && onClick) onClick(id, 'styles');
-      }}
-      onKeyPress={() => {
-        if (id && isNeedClick && onClick) onClick(id, 'styles');
-      }}
+      // TODO: 서비스 고도화 전까지 styles 데이터 주석
+      // onClick={() => {
+      //   if (id && isNeedClick && onClick) onClick(id, 'styles');
+      // }}
+      // onKeyPress={() => {
+      //   if (id && isNeedClick && onClick) onClick(id, 'styles');
+      // }}
       aria-label={`${alt} 이미지 박스`}
       ref={boxRef}
     >

--- a/src/components/shared/organisms/ImgSlide/index.tsx
+++ b/src/components/shared/organisms/ImgSlide/index.tsx
@@ -13,17 +13,17 @@ import $ from './style.module.scss';
 
 type Props = {
   imgList: (ImgProps | string)[];
-  status?: res.ProductStatus;
+  isSoldOut: boolean;
 } & DefaultProps;
 
 export default function ImgSlide(slideProps: Props) {
-  const { children, className, style, imgList, status } = slideProps;
+  const { children, className, style, imgList, isSoldOut } = slideProps;
   const [imgCurrentNo, setImgCurrentNo] = useState(0);
   const [mouseDownClientX, setMouseDownClientX] = useState(0);
   const [mouseUpClientX, setMouseUpClientX] = useState(0);
   const dragRef = useRef<HTMLDivElement>(null);
   const ref = dragRef.current;
-  const isSoldOut = status === 'soldout';
+  // const isSoldOut = status === 'soldout'; // TODO: 추후에 상품 상태 추가
   const currentImgNo = imgCurrentNo + 1;
   const imgListLen = imgList.length;
   useDragScroll(dragRef);

--- a/src/components/shared/templates/DialogModal/index.tsx
+++ b/src/components/shared/templates/DialogModal/index.tsx
@@ -2,8 +2,10 @@ import { memo } from 'react';
 
 import Button from '@atoms/Button';
 import Span from '@atoms/Span';
+import { URL_REGEX } from '@constants/regExp';
 import { Modal } from '@templates/Modal';
 import classnames from 'classnames';
+import { isSameRegExpCondition } from 'src/utils/regExp';
 
 import $ from './style.module.scss';
 
@@ -14,6 +16,7 @@ type Props = {
   isVerticalBtn?: boolean;
   title?: string;
   content?: string;
+  emphasisContent?: string;
   clickText?: string;
   cancelText?: string;
   onCancel?: () => void;
@@ -22,7 +25,9 @@ type Props = {
 
 function DialogModal(dialogProps: Props) {
   const { id, label, isOpen, isVerticalBtn, onCancel, onClick } = dialogProps;
-  const { title, content, clickText, cancelText } = dialogProps;
+  const { title, content, clickText, cancelText, emphasisContent } =
+    dialogProps;
+  const isUrl = isSameRegExpCondition(URL_REGEX, emphasisContent || '');
 
   return (
     <Modal id={`${id}-dialog-modal`} {...{ isOpen }}>
@@ -32,6 +37,20 @@ function DialogModal(dialogProps: Props) {
       >
         {title && <h2 className={$.title}>{title}</h2>}
         {content && <Span className={$.content}>{content}</Span>}
+
+        {emphasisContent &&
+          (isUrl ? (
+            <a
+              target="_blank"
+              href={emphasisContent}
+              rel="noreferrer"
+              className={$.title}
+            >
+              {emphasisContent}
+            </a>
+          ) : (
+            <h3 className={$.title}>{emphasisContent}</h3>
+          ))}
 
         <div
           className={classnames($['btn-box'], {

--- a/src/components/shared/templates/DialogModal/style.module.scss
+++ b/src/components/shared/templates/DialogModal/style.module.scss
@@ -18,6 +18,9 @@
     margin-bottom: 15px;
     @include typography(18);
     font-weight: 700;
+    &:visited {
+      color: $primary;
+    }
   }
 
   .content {

--- a/src/components/shared/templates/UploadTemplate/index.tsx
+++ b/src/components/shared/templates/UploadTemplate/index.tsx
@@ -5,8 +5,8 @@ import BackBtn from '@atoms/BackBtn';
 import ButtonFooter from '@atoms/ButtonFooter';
 import HeadMeta from '@atoms/HeadMeta';
 import { seoData } from '@constants/seo';
-import { additionData, styleData } from '@constants/upload/constants';
-import { reviewData, sizeData } from '@constants/upload/utils';
+import { additionData } from '@constants/upload/constants';
+import { reviewData, sizeData, styleData } from '@constants/upload/utils';
 import PageHeader from '@molecules/PageHeader';
 import { getBreadcrumb } from 'src/api/category';
 import AdditionInfo from 'src/components/Upload/organisms/AdditionInfo';
@@ -20,6 +20,8 @@ import SellerReview from 'src/components/Upload/organisms/SellerReview';
 import SizeInfo from 'src/components/Upload/organisms/SizeInfo';
 import StyleSelect from 'src/components/Upload/organisms/StyleSelect';
 import { useMounted, useDidMountEffect } from 'src/hooks';
+import { useCategoryTree } from 'src/hooks/api/category';
+import { useStaticData } from 'src/hooks/api/staticData';
 import { useProductUpload, useUpdateProduct } from 'src/hooks/api/upload';
 import { getJudgeCategory, getMeasureElement } from 'src/utils';
 import { toastError } from 'src/utils/toaster';
@@ -31,13 +33,24 @@ type Props = {
   id: string;
   isUpdate: boolean;
   states: UploadStoreState;
-  categoryData: res.CategoryTree['data'] | undefined;
 };
 
-function UploadTemplate({ id, isUpdate, states, categoryData }: Props) {
+function UploadTemplate({ id, isUpdate, states }: Props) {
   const isMounted = useMounted();
   const { mutate } = useProductUpload();
   const { mutate: updateMutate } = useUpdateProduct(id);
+  const categoryData = useCategoryTree(false)?.data;
+  const { data: styles } = useStaticData<res.StaticData>('Style');
+  const { data: bodyShapes } = useStaticData<res.StaticData>('BodyShape');
+  const { data: pol } = useStaticData<res.StaticData>('PollutionCondition');
+  const { data: colors } = useStaticData<res.KindStaticData>('Color');
+  const { data: sizes } = useStaticData<res.KindStaticData>('Size');
+  const { data: lengths } = useStaticData<res.KindStaticData>('Length');
+  const { data: fits } = useStaticData<res.KindStaticData>('Fit');
+  const condition1 = !categoryData || !colors || !styles || !sizes;
+  const condition2 = !pol || !lengths || !bodyShapes || !fits;
+  const noRenderCondition = condition1 || condition2;
+
   const { price, isIncludeDelivery, style, basicInfo, size, contact } = states;
   const { updateArr, updateUpload, removeImg } = states;
   const { imgUpload, clearUpload, initMeasure } = states;
@@ -65,8 +78,19 @@ function UploadTemplate({ id, isUpdate, states, categoryData }: Props) {
     () => getMeasureElement(mainCategory),
     [mainCategory],
   );
-  const sizeProps = useMemo(() => sizeData(mainCategory), [mainCategory]);
-  const review = useMemo(() => reviewData(mainCategory), [mainCategory]);
+  const styleProps = useMemo(() => styleData(styles, colors), [styles, colors]);
+  const sizeProps = useMemo(
+    () => sizeData(mainCategory, sizes),
+    [sizes, mainCategory],
+  );
+  const reviewDatas = useMemo(
+    () => ({ pollution: pol, lengths, bodyShapes, fits }),
+    [bodyShapes, fits, lengths, pol],
+  );
+  const review = useMemo(
+    () => reviewData(mainCategory, reviewDatas),
+    [mainCategory, reviewDatas],
+  );
   // TODO: 사이즈, 리뷰 데이터 state 초기화
   // TODO: 서버에서 받은 height, bodyShape 상태 저장하기
 
@@ -81,14 +105,12 @@ function UploadTemplate({ id, isUpdate, states, categoryData }: Props) {
   };
 
   useDidMountEffect(() => {
-    // TODO: 상품 수정 시 measure 값이 바뀌는 이슈
     initMeasures(measureState);
     update(mainCategory, 'measureType');
-  }, [mainCategory]); // FIX: restrictMode로 인해 실행됨.
+  }, [mainCategory]); // NOTICE: restrictMode로 인해 실행됨.
+  if (!isMounted || noRenderCondition) return null;
 
-  if (!isMounted || !categoryData) return null;
   return (
-    // TODO: form 태그로 바꾸기
     <>
       <HeadMeta
         title={`re:Fashion | 상품 ${isUpdate ? '수정' : '등록'}하기`}
@@ -103,7 +125,7 @@ function UploadTemplate({ id, isUpdate, states, categoryData }: Props) {
         title={`상품${isUpdate ? '수정' : '등록'}`}
         left={<BackBtn color="#000" className={$.back} />}
       />
-      <div className={$.upload}>
+      <form className={$.upload}>
         <ImgUpload
           {...{ isImgValid, imgUpload: imgsUpload, removeImg: removeImgs }}
           {...{ updateArr: updateArray, categoryData }}
@@ -112,7 +134,7 @@ function UploadTemplate({ id, isUpdate, states, categoryData }: Props) {
         />
         <StyleSelect
           {...{ isStyleValid }}
-          data={styleData}
+          data={styleProps}
           state={style}
           onChange={update}
         />
@@ -156,7 +178,7 @@ function UploadTemplate({ id, isUpdate, states, categoryData }: Props) {
           opinionPlaceholder="판매자님의 설명은 구매에 도움이 됩니다.(최대 300자)"
           onChange={update}
         />
-      </div>
+      </form>
       <ButtonFooter
         background="white"
         style={{ padding: '0 21px 30px' }}

--- a/src/constants/api/index.ts
+++ b/src/constants/api/index.ts
@@ -16,6 +16,8 @@ export const TOKEN_REFRESH = 'api/auth/reissue';
 export const KAKAO_OAUTH_URL = `${process.env.OAUTH_URL}&client_id=${process.env.OAUTH_CLIENT_ID}&redirect_uri=${process.env.OAUTH_REDIRECT_URI}&state=${process.env.OAUTH_STATE}&identity_provider=kakao`;
 export const GOOGLE_OAUTH_URL = `${process.env.OAUTH_URL}&client_id=${process.env.OAUTH_CLIENT_ID}&redirect_uri=${process.env.OAUTH_REDIRECT_URI}&state=${process.env.OAUTH_STATE}&identity_provider=Google`;
 
+export const ISR_MIN = 60;
+export const ISR_HOUR = 60 * 60;
 export const ISR_DAY = 60 * 60 * 24;
 export const ISR_WEEK = 60 * 60 * 24 * 7;
 export const ISR_MONTH = 60 * 60 * 24 * 30;

--- a/src/constants/api/index.ts
+++ b/src/constants/api/index.ts
@@ -9,6 +9,7 @@ export const HTTP_METHOD = {
 export const ACCESSTOKEN = 'x-access-token';
 
 export const ACCESSTOKEN_EXPIRED = 'TOKEN_EXPIRED';
+export const USER_NOT_EXISTED = 'USER_NOT_EXISTED';
 
 export const TOKEN_REFRESH = 'api/auth/reissue';
 

--- a/src/constants/regExp.ts
+++ b/src/constants/regExp.ts
@@ -1,0 +1,2 @@
+export const URL_REGEX =
+  /^(https?:\/\/)?([da-z.-]+).([a-z.]{2,6})([/\w_.#-]*)*$/;

--- a/src/constants/upload/constants.ts
+++ b/src/constants/upload/constants.ts
@@ -1,42 +1,12 @@
-import { DefaultData } from '#types/index';
 import { btnTemplateBox } from '#types/info';
-import {
-  StyleUpload,
-  UploadState,
-  AdditionalInfo,
-} from '#types/storeType/upload';
-import { colorsData, stylesData } from '@constants/index';
+import { UploadState, AdditionalInfo } from '#types/storeType/upload';
 
-type btnBox = btnTemplateBox<keyof UploadState, keyof StyleUpload> & {
-  datas: (string | DefaultData)[];
-  subType: keyof StyleUpload;
-};
-
-type btnBox2 = btnTemplateBox<keyof UploadState, keyof AdditionalInfo> & {
+type btnBox = btnTemplateBox<keyof UploadState, keyof AdditionalInfo> & {
   placeholder: string;
   subType: keyof AdditionalInfo;
 };
 
-const styleData: btnBox[] = [
-  {
-    label: '스타일 태그 선택 (1개)',
-    type: 'style',
-    subType: 'tag',
-    datas: stylesData.slice(1),
-    noCheckColor: true,
-    childrenBox: true,
-  },
-  {
-    label: '컬러 선택',
-    type: 'style',
-    subType: 'color',
-    datas: colorsData,
-    isColor: true,
-    childrenBox: true,
-  },
-];
-
-const additionData: btnBox2[] = [
+export const additionData: btnBox[] = [
   {
     label: '구매시기',
     placeholder: '한달 전, 1년 이내 등',
@@ -50,4 +20,3 @@ const additionData: btnBox2[] = [
     subType: 'purchasePlace',
   },
 ];
-export { styleData, additionData };

--- a/src/constants/upload/utils.ts
+++ b/src/constants/upload/utils.ts
@@ -1,7 +1,11 @@
 import { DefaultData } from '#types/index';
 import { btnTemplateBox } from '#types/info';
-import { bottomSizes, condition, topSizes, bodyShapes } from '@constants/basic';
-import { fitsData, lengthsData } from '@constants/style';
+import { StyleUpload, UploadState } from '#types/storeType/upload';
+
+type styleBtnBox = btnTemplateBox<keyof UploadState, keyof StyleUpload> & {
+  datas: (string | DefaultData)[];
+  subType: keyof StyleUpload;
+};
 
 export type sizeBtnBox = btnTemplateBox<'size', undefined> & {
   datas: (string | DefaultData)[];
@@ -9,11 +13,36 @@ export type sizeBtnBox = btnTemplateBox<'size', undefined> & {
 
 const isTop = (category: string) => category === 'top' || category === 'outer';
 
-export const sizeData = (category: string): sizeBtnBox => {
+export const styleData = (
+  style?: res.StaticData,
+  color?: res.KindStaticData,
+): styleBtnBox[] => [
+  {
+    label: '스타일 태그 선택 (1개)',
+    type: 'style',
+    subType: 'tag',
+    datas: style?.data || [],
+    noCheckColor: true,
+    childrenBox: true,
+  },
+  {
+    label: '컬러 선택',
+    type: 'style',
+    subType: 'color',
+    datas: color?.data.top || [],
+    isColor: true,
+    childrenBox: true,
+  },
+];
+
+export const sizeData = (
+  category: string,
+  sizes?: res.KindStaticData,
+): sizeBtnBox => {
   return {
     label: '사이즈',
     type: 'size',
-    datas: isTop(category) ? topSizes : bottomSizes,
+    datas: (isTop(category) ? sizes?.data.top : sizes?.data.bottom) || [],
     noCheckColor: true,
     required: true,
   };
@@ -21,14 +50,34 @@ export const sizeData = (category: string): sizeBtnBox => {
 
 const allSlice = (arr: DefaultData[]) => arr.slice(1);
 
-export const reviewData = (category: string) => {
+type ReviewDatasInput = {
+  pollution?: res.StaticData;
+  lengths?: res.KindStaticData;
+  bodyShapes?: res.StaticData;
+  fits?: res.KindStaticData;
+};
+
+type ReviewDatasOutput = {
+  condition: DefaultData[];
+  pollution: DefaultData[];
+  length: DefaultData[];
+  bodyShapes: DefaultData[];
+  fit: DefaultData[];
+};
+
+export const reviewData = (
+  category: string,
+  reviewDatas: ReviewDatasInput,
+): ReviewDatasOutput => {
   return {
-    condition,
-    pollution: condition,
-    fit: isTop(category) ? allSlice(fitsData.top) : allSlice(fitsData.bottom),
-    bodyShapes,
+    condition: reviewDatas.pollution?.data || [],
+    pollution: reviewDatas.pollution?.data || [],
+    fit: isTop(category)
+      ? allSlice(reviewDatas.fits?.data.top || [])
+      : allSlice(reviewDatas.fits?.data.bottom || []),
+    bodyShapes: reviewDatas.bodyShapes?.data || [],
     length: isTop(category)
-      ? allSlice(lengthsData.top)
-      : allSlice(lengthsData.bottom),
+      ? allSlice(reviewDatas.lengths?.data.top || [])
+      : allSlice(reviewDatas.lengths?.data.top || []),
   };
 };

--- a/src/hooks/api/category/index.ts
+++ b/src/hooks/api/category/index.ts
@@ -8,7 +8,6 @@ export const useCategoryTree = (isExcluded: boolean) => {
     queryKey.category(isExcluded),
     () => (isExcluded ? getExcludeCategory() : getCategory()),
     {
-      cacheTime: QUERY_DAYTIME,
       staleTime: QUERY_DAYTIME,
       suspense: true,
     },

--- a/src/hooks/api/staticData/index.ts
+++ b/src/hooks/api/staticData/index.ts
@@ -1,11 +1,15 @@
-import { queryKey } from '@constants/react-query';
+import { queryKey, QUERY_WEEKTIME } from '@constants/react-query';
 import { getStaticData } from 'src/api/staticData';
 
 import { useCoreQuery } from '../core';
 
 export const useStaticData = <T>(type: req.StaticType) => {
-  const response = useCoreQuery(queryKey.staticData(type), () =>
-    getStaticData<T>(type),
+  const response = useCoreQuery(
+    queryKey.staticData(type),
+    () => getStaticData<T>(type),
+    {
+      staleTime: QUERY_WEEKTIME,
+    },
   );
   return response;
 };

--- a/src/pages/info/basic/index.tsx
+++ b/src/pages/info/basic/index.tsx
@@ -51,21 +51,9 @@ export function BasicInfo() {
   const inputRef = useRef<HTMLInputElement>(null);
   const updateInfo = useInfoStore(useCallback((stat) => stat.infoUpdate, []));
   const router = useRouter();
-  const {
-    isLoading: genderIsLoading,
-    isError: genderIsError,
-    data: genderData,
-  } = useStaticData<res.StaticData>('Gender');
-  const {
-    isLoading: bodyIsLoading,
-    isError: bodyIsError,
-    data: bodyData,
-  } = useStaticData<res.StaticData>('BodyShape');
-  const {
-    isLoading: sizeIsLoading,
-    isError: sizeIsError,
-    data: sizeData,
-  } = useStaticData<res.KindStaticData>('Size');
+  const { data: genderData } = useStaticData<res.StaticData>('Gender');
+  const { data: bodyData } = useStaticData<res.StaticData>('BodyShape');
+  const { data: sizeData } = useStaticData<res.KindStaticData>('Size');
   const restData = [bodyData?.data, sizeData?.data.top, sizeData?.data.bottom];
 
   const heightChangeCallback = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/pages/info/basic/index.tsx
+++ b/src/pages/info/basic/index.tsx
@@ -16,6 +16,7 @@ import InfoPageNum from '@molecules/InfoPageNum';
 import InfoBtnBox from '@organisms/InfoBtnBox';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';
+import { withGetServerSideProps } from 'src/api/core/withGetServerSideProps';
 import { getStaticData } from 'src/api/staticData';
 import { useStaticData } from 'src/hooks/api/staticData';
 import { useInfoStore } from 'src/store/useInfoStore';
@@ -24,16 +25,16 @@ import { toastError } from 'src/utils/toaster';
 
 import $ from './style.module.scss';
 
-export async function getStaticProps() {
+export const getStaticProps = withGetServerSideProps(async () => {
   const queryClient = new QueryClient();
 
-  await queryClient.prefetchQuery(queryKey.staticData('Gender'), () =>
+  await queryClient.fetchQuery(queryKey.staticData('Gender'), () =>
     getStaticData('Gender'),
   );
-  await queryClient.prefetchQuery(queryKey.staticData('BodyShape'), () =>
+  await queryClient.fetchQuery(queryKey.staticData('BodyShape'), () =>
     getStaticData('BodyShape'),
   );
-  await queryClient.prefetchQuery(queryKey.staticData('Size'), () =>
+  await queryClient.fetchQuery(queryKey.staticData('Size'), () =>
     getStaticData('Size'),
   );
 
@@ -43,7 +44,7 @@ export async function getStaticProps() {
     },
     revalidate: ISR_WEEK,
   };
-}
+});
 
 export function BasicInfo() {
   const state = useInfoStore((stat) => stat);
@@ -104,7 +105,7 @@ export function BasicInfo() {
         url={`${seoData.url}/info/basic`}
       />
 
-      <InfoPageNum>2/3</InfoPageNum>
+      <InfoPageNum>1/2</InfoPageNum>
       <InfoHeader title="basic">
         성별, 키, 체형 및 사이즈를 알려주세요.
         <br /> 사이즈는 복수 선택도 가능해요.

--- a/src/pages/info/color/index.tsx
+++ b/src/pages/info/color/index.tsx
@@ -40,8 +40,7 @@ export const getStaticProps = withGetServerSideProps(async () => {
 export function ColorInfo() {
   const state = useInfoStore((stat) => stat);
   const handleClick = useInfoStore(useCallback((stat) => stat.infoUpdate, []));
-  const { isLoading, isError, data, error } =
-    useStaticData<res.KindStaticData>('Color');
+  const { isLoading, data } = useStaticData<res.KindStaticData>('Color');
   const { mutate } = usePostPreference();
   const router = useRouter();
   const colorData = [data?.data.top, data?.data.bottom];

--- a/src/pages/info/color/index.tsx
+++ b/src/pages/info/color/index.tsx
@@ -13,6 +13,7 @@ import InfoPageNum from '@molecules/InfoPageNum';
 import InfoBtnBox from '@organisms/InfoBtnBox';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';
+import { withGetServerSideProps } from 'src/api/core/withGetServerSideProps';
 import { getStaticData } from 'src/api/staticData';
 import { usePostPreference } from 'src/hooks/api/preference';
 import { useStaticData } from 'src/hooks/api/staticData';
@@ -21,10 +22,10 @@ import { refinePreferenceData } from 'src/utils/preference.utils';
 
 import $ from './style.module.scss';
 
-export async function getStaticProps() {
+export const getStaticProps = withGetServerSideProps(async () => {
   const queryClient = new QueryClient();
 
-  await queryClient.prefetchQuery(queryKey.staticData('Color'), () =>
+  await queryClient.fetchQuery(queryKey.staticData('Color'), () =>
     getStaticData('Color'),
   );
 
@@ -34,7 +35,7 @@ export async function getStaticProps() {
     },
     revalidate: ISR_WEEK,
   };
-}
+});
 
 export function ColorInfo() {
   const state = useInfoStore((stat) => stat);
@@ -59,7 +60,7 @@ export function ColorInfo() {
         url={`${seoData.url}/info/color`}
       />
 
-      <InfoPageNum>3/3</InfoPageNum>
+      <InfoPageNum>2/2</InfoPageNum>
 
       <InfoHeader title="color">
         선호하는 컬러를 알려주세요.

--- a/src/pages/info/style/index.tsx
+++ b/src/pages/info/style/index.tsx
@@ -12,23 +12,24 @@ import InfoHeader from '@molecules/InfoHeader';
 import InfoPageNum from '@molecules/InfoPageNum';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';
+import { withGetServerSideProps } from 'src/api/core/withGetServerSideProps';
 import { getStyleImgs } from 'src/api/preference';
 import { useStyleImgs } from 'src/hooks/api/preference';
 import { useInfoStore } from 'src/store/useInfoStore';
 
 import $ from './style.module.scss';
 
-export async function getStaticProps() {
+export const getStaticProps = withGetServerSideProps(async () => {
   const queryClient = new QueryClient();
 
-  await queryClient.prefetchQuery(queryKey.styleImgs, getStyleImgs);
+  await queryClient.fetchQuery(queryKey.styleImgs, getStyleImgs);
 
   return {
     props: {
       dehydratedState: dehydrate(queryClient),
     },
   };
-}
+});
 
 const skeletonImgBox = Array.from({ length: 20 });
 

--- a/src/pages/shop/[id]/index.tsx
+++ b/src/pages/shop/[id]/index.tsx
@@ -45,10 +45,10 @@ function ShopDetail({ id }: { id: string }) {
   const detailData = data?.data;
 
   if (detailData) {
-    const { isMe, sellerInfo, basic, sellerNotice, measure } = detailData;
-    const { opinion, price, isIncludeDelivery, updatedAt, like, views } =
-      detailData;
-    const status = 'soldout'; // TODO: 백엔드와 협의
+    const { isMe, isSoldOut, sellerInfo, basic, sellerNotice } = detailData;
+    const { measure, opinion, price, isIncludeDelivery } = detailData;
+    const { updatedAt, like, views, contact } = detailData;
+    // const status = 'soldout'; // TODO: 백엔드와 협의, 추후에 상품 상태 추가
     addProduct({ id: +id, img: sellerInfo.image[0] });
 
     return (
@@ -60,7 +60,7 @@ function ShopDetail({ id }: { id: string }) {
 
         <Layout noPadding className={$['shop-detail-layout']}>
           <ProductImgSlide
-            {...{ id, isMe, status, imgList: sellerInfo.image }}
+            {...{ id, isMe, isSoldOut, imgList: sellerInfo.image }}
           />
           <Profile profile={sellerInfo} />
           <section className={$['shop-detail-info']}>
@@ -74,7 +74,8 @@ function ShopDetail({ id }: { id: string }) {
             )}
             <ProductFooter
               footer={{
-                ...{ price, isIncludeDelivery, updatedAt, like, views },
+                ...{ price, isIncludeDelivery, updatedAt },
+                ...{ like, views, contact },
               }}
             >
               연락하기

--- a/src/pages/shop/[id]/index.tsx
+++ b/src/pages/shop/[id]/index.tsx
@@ -3,6 +3,7 @@ import { GetServerSidePropsContext } from 'next';
 import { useCallback } from 'react';
 
 import HeadMeta from '@atoms/HeadMeta';
+import { queryKey } from '@constants/react-query';
 import { seoData } from '@constants/seo';
 import Profile from '@molecules/Profile';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
@@ -26,7 +27,9 @@ export const getServerSideProps = withGetServerSideProps(
     const id = params?.id;
     const paramId = (typeof id !== 'object' && id) || '0';
 
-    await queryClient.fetchQuery(['styles'], () => getProductDetail(paramId));
+    await queryClient.fetchQuery(queryKey.productDetail(paramId), () =>
+      getProductDetail(paramId),
+    );
 
     return {
       props: {

--- a/src/pages/upload/[id]/index.tsx
+++ b/src/pages/upload/[id]/index.tsx
@@ -1,13 +1,13 @@
 import { ReactElement, useCallback, useEffect } from 'react';
 
-import { queryKey } from '@constants/react-query';
+import { queryKey, QUERY_WEEKTIME } from '@constants/react-query';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';
 import UploadTemplate from '@templates/UploadTemplate';
 import { getCategory } from 'src/api/category';
 import { withGetServerSideProps } from 'src/api/core/withGetServerSideProps';
+import { getStaticData } from 'src/api/staticData';
 import { getUploadedProduct } from 'src/api/upload';
-import { useCategoryTree } from 'src/hooks/api/category';
 import { useUploadedProduct } from 'src/hooks/api/upload';
 import { useUploadUpdateStore } from 'src/store/upload/useUploadUpdateStore';
 import { uploadedDataToState } from 'src/utils/upload.utils';
@@ -15,9 +15,64 @@ import { uploadedDataToState } from 'src/utils/upload.utils';
 export const getServerSideProps = withGetServerSideProps(async ({ params }) => {
   const id = params?.id as string;
   const queryClient = new QueryClient();
-  await queryClient.fetchQuery(queryKey.category(false), () => getCategory());
-  await queryClient.fetchQuery(queryKey.uploadedProduct(id), () =>
-    getUploadedProduct(id),
+  await queryClient.fetchQuery(queryKey.category(false), () => getCategory(), {
+    staleTime: QUERY_WEEKTIME,
+  });
+  await queryClient.fetchQuery(
+    queryKey.staticData('Style'),
+    () => getStaticData('Style'),
+    {
+      staleTime: QUERY_WEEKTIME,
+    },
+  );
+  await queryClient.fetchQuery(
+    queryKey.staticData('Color'),
+    () => getStaticData('Color'),
+    {
+      staleTime: QUERY_WEEKTIME,
+    },
+  );
+  await queryClient.fetchQuery(
+    queryKey.staticData('Size'),
+    () => getStaticData('Size'),
+    {
+      staleTime: QUERY_WEEKTIME,
+    },
+  );
+  await queryClient.fetchQuery(
+    queryKey.staticData('PollutionCondition'),
+    () => getStaticData('PollutionCondition'),
+    {
+      staleTime: QUERY_WEEKTIME,
+    },
+  );
+  await queryClient.fetchQuery(
+    queryKey.staticData('Length'),
+    () => getStaticData('Length'),
+    {
+      staleTime: QUERY_WEEKTIME,
+    },
+  );
+  await queryClient.fetchQuery(
+    queryKey.staticData('BodyShape'),
+    () => getStaticData('BodyShape'),
+    {
+      staleTime: QUERY_WEEKTIME,
+    },
+  );
+  await queryClient.fetchQuery(
+    queryKey.staticData('Fit'),
+    () => getStaticData('Fit'),
+    {
+      staleTime: QUERY_WEEKTIME,
+    },
+  );
+  await queryClient.fetchQuery(
+    queryKey.uploadedProduct(id),
+    () => getUploadedProduct(id),
+    {
+      staleTime: QUERY_WEEKTIME,
+    },
   );
 
   return {
@@ -30,7 +85,6 @@ export const getServerSideProps = withGetServerSideProps(async ({ params }) => {
 
 function UploadUpdate({ id }: { id: string }) {
   const { data } = useUploadedProduct(id);
-  const categoryData = useCategoryTree(false)?.data;
   const states = useUploadUpdateStore((state) => state);
   const { initState } = states;
   const initUploads = useCallback(initState, [initState]);
@@ -40,8 +94,7 @@ function UploadUpdate({ id }: { id: string }) {
     if (state) initUploads(state);
   }, []);
 
-  if (!categoryData || !data) return null;
-  return <UploadTemplate {...{ id, states, categoryData, isUpdate: true }} />;
+  return <UploadTemplate {...{ id, states, isUpdate: true }} />;
 }
 
 UploadUpdate.getLayout = function getLayout(page: ReactElement) {

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -9,7 +9,7 @@ import Layout from '@templates/Layout';
 import UploadTemplate from '@templates/UploadTemplate';
 import { getCategory } from 'src/api/category';
 import { withGetServerSideProps } from 'src/api/core/withGetServerSideProps';
-import { useCategoryTree } from 'src/hooks/api/category';
+import { getStaticData } from 'src/api/staticData';
 import { useUploadStore } from 'src/store/upload/useUploadStore';
 import { toastError } from 'src/utils/toaster';
 import { judgeValid } from 'src/utils/upload.utils';
@@ -17,7 +17,27 @@ import { judgeValid } from 'src/utils/upload.utils';
 export const getStaticProps = withGetServerSideProps(async () => {
   const queryClient = new QueryClient();
   await queryClient.fetchQuery(queryKey.category(false), () => getCategory());
-
+  await queryClient.fetchQuery(queryKey.staticData('Style'), () =>
+    getStaticData('Style'),
+  );
+  await queryClient.fetchQuery(queryKey.staticData('Color'), () =>
+    getStaticData('Color'),
+  );
+  await queryClient.fetchQuery(queryKey.staticData('Size'), () =>
+    getStaticData('Size'),
+  );
+  await queryClient.fetchQuery(queryKey.staticData('PollutionCondition'), () =>
+    getStaticData('PollutionCondition'),
+  );
+  await queryClient.fetchQuery(queryKey.staticData('Length'), () =>
+    getStaticData('Length'),
+  );
+  await queryClient.fetchQuery(queryKey.staticData('BodyShape'), () =>
+    getStaticData('BodyShape'),
+  );
+  await queryClient.fetchQuery(queryKey.staticData('Fit'), () =>
+    getStaticData('Fit'),
+  );
   return {
     props: {
       dehydratedState: dehydrate(queryClient),
@@ -28,7 +48,6 @@ export const getStaticProps = withGetServerSideProps(async () => {
 
 function Upload() {
   const router = useRouter();
-  const categoryData = useCategoryTree(false)?.data;
   const states = useUploadStore((state) => state);
   const { isRemainState } = judgeValid(states);
 
@@ -45,9 +64,7 @@ function Upload() {
     };
   }, [backBtnClick, router.events, router.pathname]);
 
-  return (
-    <UploadTemplate {...{ id: '-1', states, categoryData, isUpdate: false }} />
-  );
+  return <UploadTemplate {...{ id: '-1', states, isUpdate: false }} />;
 }
 
 Upload.getLayout = function getLayout(page: ReactElement) {

--- a/src/store/upload/UploadSlice.ts
+++ b/src/store/upload/UploadSlice.ts
@@ -1,9 +1,8 @@
+import { ImgBasicProps } from '#types/index';
+import { UploadStoreState, Measure } from '#types/storeType/upload';
 import { isObjectType, uploadInitialState } from 'src/store/constants';
 import { deepClone, updateInfo } from 'src/utils';
 import { StateCreator } from 'zustand';
-
-import { ImgBasicProps } from '#types/index';
-import { UploadStoreState, Measure } from '#types/storeType/upload';
 
 export type UploadSlice = UploadStoreState;
 

--- a/src/types/apiTypes/product.d.ts
+++ b/src/types/apiTypes/product.d.ts
@@ -4,6 +4,7 @@ declare namespace res {
     data: {
       isMe: boolean;
       isSoldOut: boolean;
+      contact: string;
       sellerInfo: {
         profileImg: string;
         nickname: string;

--- a/src/types/apiTypes/product.d.ts
+++ b/src/types/apiTypes/product.d.ts
@@ -3,7 +3,7 @@ declare namespace res {
     status: number;
     data: {
       isMe: boolean;
-      status: string;
+      isSoldOut: boolean;
       sellerInfo: {
         profileImg: string;
         nickname: string;
@@ -21,7 +21,7 @@ declare namespace res {
         pollution: string;
         height: string;
         length: string;
-        bodyForm: string;
+        bodyShape: string;
         fit: string;
         purchaseTime: string;
         purchasePlace: string;
@@ -44,5 +44,5 @@ declare namespace res {
       views: number;
     };
   };
-  type ProductStatus = 'soldout' | 'sale' | 'reserve';
+  type ProductStatus = 'soldout' | 'sale' | 'reserve'; // TODO: 추후에 상품 상태 추가
 }

--- a/src/types/apiTypes/staticData.d.ts
+++ b/src/types/apiTypes/staticData.d.ts
@@ -6,7 +6,8 @@ declare namespace req {
     | 'Length'
     | 'Size'
     | 'Style'
-    | 'BodyShape';
+    | 'BodyShape'
+    | 'PollutionCondition';
 }
 
 declare namespace res {

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -11,7 +11,7 @@ export type ProductNoticeInfo = {
   pollution: string;
   height: string;
   length: string;
-  bodyForm: string;
+  bodyShape: string;
   fit: string;
   purchaseTime?: string;
   purchasePlace?: string;
@@ -34,4 +34,5 @@ export type ProductFooterInfo = {
   updatedAt: string;
   like: number;
   views: number;
+  contact: string;
 };

--- a/src/utils/product.ts
+++ b/src/utils/product.ts
@@ -27,7 +27,7 @@ export const productNoticeUtil = (notice: ProductNoticeInfo) => {
     pollution,
     height,
     length,
-    bodyForm,
+    bodyShape,
     fit,
     purchaseTime,
     purchasePlace,
@@ -37,7 +37,7 @@ export const productNoticeUtil = (notice: ProductNoticeInfo) => {
     { label: '사용감', desc: condition },
     { label: '오염 여부', desc: pollution },
     { label: '기장', desc: `키 ${height}cm 기준, ${length}까지` },
-    { label: `${bodyForm}체형 기준`, desc: `${fit}핏이에요` },
+    { label: `${bodyShape}체형 기준`, desc: `${fit}핏이에요` },
     { label: '구매시기', desc: purchaseTime },
     { label: '구매처', desc: purchasePlace },
   ];

--- a/src/utils/regExp.ts
+++ b/src/utils/regExp.ts
@@ -1,0 +1,2 @@
+export const isSameRegExpCondition = (condition: RegExp, str: string) =>
+  condition.test(str);

--- a/src/utils/upload.utils.ts
+++ b/src/utils/upload.utils.ts
@@ -44,7 +44,6 @@ const judgeValid = (states: UploadState) => {
       tagValid &&
       materialValid &&
       priceValid &&
-      deliveryValid &&
       titleValid &&
       categoryValid &&
       brandValid &&

--- a/src/utils/upload.utils.ts
+++ b/src/utils/upload.utils.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { UploadState, UploadStoreState } from '#types/storeType/upload';
+import { imageList } from 'src/components/Upload/organisms/ImgUpload/utils';
 import { uploadInitialState } from 'src/store/constants';
 
 import { arrToString } from './arrToString';
@@ -75,14 +76,14 @@ const refineUploadData = (data: UploadStoreState): req.UploadData => {
     ...rest,
     imgList: imgList.map(({ src }) => src),
     basicInfo: {
-      ...basicInfo,
+      title: basicInfo.title,
+      brand: basicInfo.brand,
       category: basicInfo.category[basicInfo.category.length - 1],
     },
     style: {
       ...style,
       color: arrToString(style.color),
     },
-    measureType: rest.measureType?.toUpperCase() || null,
     measure: Object.entries(measure).reduce((acc, [key, value]) => {
       if (typeof value === 'number')
         return {
@@ -107,7 +108,7 @@ const uploadedDataToState = (
   return {
     ...uploadInitialState,
     ...data.data,
-    imgList: imgList.map((img, id) => ({ id: id + 1, src: img })),
+    imgList: imageList(imgList),
     basicInfo: {
       ...basicInfo,
       category: [gender, main, category],
@@ -117,7 +118,6 @@ const uploadedDataToState = (
       ...style,
       color: style.color.split('/'),
     },
-    measureType: data.data.measureType?.toLowerCase() || null,
   };
 };
 


### PR DESCRIPTION
## 💡 이슈
resolve #129 

## 🤩 개요
상품 QA, 연락하기 모달 추가 및 업로드에 static데이터 불러오기

## 🧑‍💻 작업 사항

### 상품 QA
- 상품 업로드 확인
- 상품 수정(measureType이 바뀌어 사용자가 입력했던 measure값이 초기화되는 이슈)
- 상품 삭제(서버 측의 404 이슈)

### 업로드 static데이터 불러오기
- 업로드 페이지에는 ISR적용(일주일)
- 상품 수정 페이지에는 SSR적용(추후 cache-control헤더 추가, 현재는 react-query staleTime 일주일로 지정)

### 연락하기 모달 추가
- url의 경우 a태그 사용하여 UX높임

### 이미지 업로드 실패 시 버그 추후에 수정

- 이미지 업로드 실패 시 모달이 나타나는 버그

https://user-images.githubusercontent.com/62797441/198515667-bcf05f4f-ac7e-45ae-acb1-f508483f1636.mov

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.
