### PR TITLE
[Bug] CSR에서 쿠키를 서버에 보내지 못하는 오류 해결

### DIFF
--- a/src/api/core/index.ts
+++ b/src/api/core/index.ts
@@ -1,10 +1,5 @@
 /* eslint-disable no-param-reassign */
-import {
-  ACCESSTOKEN,
-  ACCESSTOKEN_EXPIRED,
-  HTTP_METHOD,
-  TOKEN_REFRESH,
-} from '@constants/api';
+import { ACCESSTOKEN, ACCESSTOKEN_EXPIRED, HTTP_METHOD } from '@constants/api';
 import axios, {
   AxiosError,
   AxiosRequestConfig,
@@ -19,7 +14,7 @@ import ErrorInterceptor from './errorInterceptor';
 
 export const axiosInstance = axios.create({
   baseURL: process.env.API_URL,
-  timeout: 3000,
+  timeout: 5000,
   withCredentials: true,
   headers: {
     'Content-type': 'application/json',
@@ -29,7 +24,7 @@ export const axiosInstance = axios.create({
 
 const AiAxios = axios.create({
   baseURL: process.env.AI_API_URL,
-  timeout: 10000,
+  timeout: 20000,
   headers: {
     'Content-type': 'multipart/form-data',
   },
@@ -50,7 +45,9 @@ const handleResponse = <T>(response: AxiosResponse<T>) => {
 
 export const refreshAccessToken = async (err: AxiosError) => {
   try {
-    const response = await axiosInstance.get<res.reissue>(TOKEN_REFRESH);
+    const response = await axiosInstance.get<res.reissue>(
+      `${process.env.CLIENT_URL}api/refresh`,
+    );
     const {
       data: { accessToken },
     } = response.data;

--- a/src/pages/api/refresh.ts
+++ b/src/pages/api/refresh.ts
@@ -1,0 +1,25 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import { TOKEN_REFRESH } from '@constants/api/index';
+import { axiosInstance } from 'src/api/core';
+import { isAxiosError } from 'src/api/core/error';
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    const { data, headers: returnedHeaders } =
+      await axiosInstance.get<res.reissue>(
+        `${process.env.API_URL}${TOKEN_REFRESH}`,
+      );
+    const { accessToken } = data.data;
+    Object.entries(returnedHeaders).forEach(([key, value]) => {
+      res.setHeader(key, value as string);
+    });
+    res.setHeader('Set-Cookie', `x-access-token=${accessToken}`);
+    res.send(data);
+  } catch (err) {
+    if (isAxiosError<res.error>(err) && err.response) {
+      const { status, data } = err.response;
+      res.status(status).json(data);
+    }
+  }
+};

--- a/src/pages/info/basic/index.tsx
+++ b/src/pages/info/basic/index.tsx
@@ -16,7 +16,6 @@ import InfoPageNum from '@molecules/InfoPageNum';
 import InfoBtnBox from '@organisms/InfoBtnBox';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';
-import { withGetServerSideProps } from 'src/api/core/withGetServerSideProps';
 import { getStaticData } from 'src/api/staticData';
 import { useStaticData } from 'src/hooks/api/staticData';
 import { useInfoStore } from 'src/store/useInfoStore';

--- a/src/pages/info/color/index.tsx
+++ b/src/pages/info/color/index.tsx
@@ -13,7 +13,6 @@ import InfoPageNum from '@molecules/InfoPageNum';
 import InfoBtnBox from '@organisms/InfoBtnBox';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';
-import { withGetServerSideProps } from 'src/api/core/withGetServerSideProps';
 import { getStaticData } from 'src/api/staticData';
 import { usePostPreference } from 'src/hooks/api/preference';
 import { useStaticData } from 'src/hooks/api/staticData';

--- a/src/pages/info/style/index.tsx
+++ b/src/pages/info/style/index.tsx
@@ -12,7 +12,6 @@ import InfoHeader from '@molecules/InfoHeader';
 import InfoPageNum from '@molecules/InfoPageNum';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';
-import { withGetServerSideProps } from 'src/api/core/withGetServerSideProps';
 import { getStyleImgs } from 'src/api/preference';
 import { useStyleImgs } from 'src/hooks/api/preference';
 import { useInfoStore } from 'src/store/useInfoStore';


### PR DESCRIPTION
## 💡 이슈
resolve #135 

## 🤩 개요
CSR에서 쿠키를 서버에 보내지 못하는 오류 해결

## 🧑‍💻 작업 사항
### CSR에서 쿠키를 서버에 보내지 못하는 오류
우리 서버는 `httpOnly`, `secure` 쿠키 방식으로 `refreshToken`을 클라이언트에 보내주고 있다. 때문에 `xss` 공격을 어느정도 방어할 수 있고 `secure`의 경우에는 `https`를 통해서만 쿠키를 저장할 수 있다. 또한, `domain`을 지정해주면 해당 도메인에만 클라이언트에서 쿠키를 헤더에 담아 전송할 수 있고 `withCredentials`옵션을 통해 가능하다. 하지만 `domain`을 지정하는 것을 전혀 모르고 있었다.. 콘솔과 네트워크 탭을 확인하며 의미 없는 삽질을 이어가다 소마 동료 개발자분과 함께 고민하다가 `domain`을 지정했는지 여쭈어서 검색해보고 알게 되었다.. 모든 것은 공식 문서를 먼저 읽고 시작하는 것이 먼저라는 사실을 또 다시 한 번 깨닫는다..

여기까지 서버로부터 쿠키를 받아 해결됐지만 한가지 문제 사항이 생긴다. `SSR`에서 `reissue`를 하게 되면 클라이언트 쿠키에 접근할 수 없으므로 `cookie`를 `set`하지 못하는 것이다. 또한, `axios` 응답을 `setHeader`할 수 없으므로 중간에서 프록시 서버 역할을 해주는 `api`가 필요하다. `api route`를 통해 가능하다. 때문에 `api route`를 통해 `reissue`를 할 때는 `api route`에 요청하고 `api route`에서 요청을 받고 성공하면 `setHeader`를 통해 쿠키를 저장한다.

### getStaticProps에서 redirect를 사용하지 못하는 이유
`Error: 'redirect' can not be returned from getStaticProps during prerendering`라는 오류가 나타난다. 이유는 SSR함수를 감쌀 HOC함수를 getStaticProps에서 사용했기 때문이다. 왜 이게 문제가 생길까? 공식 문서에는 분명 getStaticProps에 redirect옵션이 나와있다..?????? 하지만 오류를 뱉는다•••••• 그럼 이유를 찾아야지.. 조금만 생각해봐도 답이 나온다. 정적 생성인데 인증을 확인하는 작업이 될리가 없다. build에서만 실행하기 때문이다. 따라서 SSG을 사용할 때는 인증을 사용하면 안된다는 결론이 나왔다. 물론 방법이 있을 수도.. 하지만 현재 제 짧은 지식으론 해결X 그리하여 백엔드 개발자분에게 SSG가 필요한 페이지에 토큰 인증 과정을 지워달라는 요청을 했다.

info/basic, info/color, upload 페이지이다. 왜 인증을 빼도 될까? 이 페이지들은 들어가는 데이터들이 정말 많다.. 매번 요청하면 서버에 부담이 되고 당연히 클라이언트에서도 부담이 생긴다. 또한, 데이터가 노출되어도 되는 데이터이다. 따라서 SSG를 사용하기로 했다. 하지만 여기서 또 문제가 생긴다. upload페이지는 인증된 사용자만 접근해야 한다... 허허 이 문제는 다음 PR에서 기술하도록 할 예정입니다.

## 📖 참고 사항
### 쿠키가 담기지 않는 상황
![쿠키 오류 해결](https://user-images.githubusercontent.com/62797441/199571947-909cc631-5939-4b69-8583-1ea2e442ba37.png)

### 이슈 해결
![쿠키 오류 해결](https://user-images.githubusercontent.com/62797441/199571972-c49070da-7d58-4b39-8dcb-c536213a1660.png)



[모던 자바스크립트 쿠키](https://ko.javascript.info/cookie#ref-3635)
[getStaticProps에서 redirect 오류](https://github.com/vercel/next.js/discussions/11346)
