### PR TITLE
[Feat] 이미지 업로드 결과 모달에 보여주기

### DIFF
--- a/src/components/MyPage/template/InfoModifyTemplate.tsx
+++ b/src/components/MyPage/template/InfoModifyTemplate.tsx
@@ -66,6 +66,7 @@ function InfoModifyTemplate(templateProps: Props) {
       left={<BackBtn color="#000" />}
       isNeedFooter={false}
       paddingTop="88px"
+      paddingBottom="110px"
       sidePadding="24px"
     >
       <ProfileImgUpload

--- a/src/components/Search/organisms/SearchHeader/index.tsx
+++ b/src/components/Search/organisms/SearchHeader/index.tsx
@@ -22,7 +22,7 @@ function SearchHeader(headerProps: Props) {
   );
   const valueQuery = useQueryRouter('value');
   const replaceValueQuery = useQueryRouter('value', 'REPLACE');
-  const queryHideSold = useQueryRouter('hide_sold', 'REPLACE');
+  const queryHideSold = useQueryRouter('hideSold', 'REPLACE');
   const queryOrder = useQueryRouter('order', 'REPLACE');
   const searchQuery = searchWord ? replaceValueQuery : valueQuery;
 

--- a/src/components/Shop/Organisms/FilterModal/utils.ts
+++ b/src/components/Shop/Organisms/FilterModal/utils.ts
@@ -18,12 +18,12 @@ export type btnBox = btnTemplateBox<
 
 type FilterElement = {
   style: string;
-  price_goe: string;
-  price_loe: string;
+  priceGoe: string;
+  priceLoe: string;
   color: string;
   fit: string;
   length: string;
-  clothes_size: string;
+  clothesSize: string;
 };
 
 const commonProps: btnBox[] = [
@@ -85,12 +85,12 @@ export const getFilterElement = (
   const { style, price, color, fit, length, clothesSize } = states;
   const common = {
     style: style.join(','),
-    price_goe: Math.min(...price).toString(),
-    price_loe: Math.max(...price).toString(),
+    priceGoe: Math.min(...price).toString(),
+    priceLoe: Math.max(...price).toString(),
     color: '',
     fit: '',
     length: '',
-    clothes_size: '',
+    clothesSize: '',
   };
 
   if (category === 'all') return common;
@@ -99,7 +99,7 @@ export const getFilterElement = (
     color: color[category].join(','),
     fit: fit[category].join(','),
     length: length[category].join(','),
-    clothes_size: clothesSize[category].join(','),
+    clothesSize: clothesSize[category].join(','),
   };
 };
 

--- a/src/components/Shop/Organisms/ShopHeader/index.tsx
+++ b/src/components/Shop/Organisms/ShopHeader/index.tsx
@@ -23,7 +23,7 @@ function ShopHeader(headerProps: Props) {
   const pushCtgr = useQueryRouter('category');
   const replaceCtgr = useQueryRouter('category', 'REPLACE');
   const queryOrder = useQueryRouter('order', 'REPLACE');
-  const queryHideSold = useQueryRouter('hide_sold', 'REPLACE');
+  const queryHideSold = useQueryRouter('hideSold', 'REPLACE');
   const { categoryQuery, orderQuery, hideSoldQuery } = headerProps;
   const { genderSelectMenu, selectData } = headerProps;
   const { genderQuery, breadCrumb } = headerProps;

--- a/src/components/Upload/atoms/FailText/index.tsx
+++ b/src/components/Upload/atoms/FailText/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import Span from '@atoms/Span';
+
+function FailText() {
+  return (
+    <Span fontWeight={500}>
+      이미지 인식에 성공하는 경우 스타일 정보(태그, 컬러, 소재) 아이템 기본
+      정보(카테고리)를 자동으로 채워줍니다.
+      <br />
+      <br />
+      이미지 인식을 원하는 경우 다른 사진을 올려주세요. 혹은 입력 항목을 직접
+      수정해주세요.
+    </Span>
+  );
+}
+export default FailText;

--- a/src/components/Upload/atoms/SuccessText/index.tsx
+++ b/src/components/Upload/atoms/SuccessText/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { recognitionResult } from '#types/upload';
+import Span from '@atoms/Span';
+
+type Props = Omit<recognitionResult, 'state'>;
+
+function SuccessText(props: Props) {
+  const { tag, color, material, category } = props;
+  return (
+    <Span fontWeight={500}>
+      스타일: <Span fontWeight={700}>{tag}</Span>
+      <br />
+      컬러: <Span fontWeight={700}>{color}</Span>
+      <br /> 소재: <Span fontWeight={700}>{material}</Span>
+      <br />
+      카테고리: <Span fontWeight={700}>{category}</Span>가 성공적으로
+      인식되었습니다.
+      <br />
+      <br />
+      인식 결과가 예상과 다르다면 입력 항목을 직접 수정해주세요.
+    </Span>
+  );
+}
+export default SuccessText;

--- a/src/components/Upload/organisms/ImgResultModal/index.tsx
+++ b/src/components/Upload/organisms/ImgResultModal/index.tsx
@@ -2,28 +2,35 @@ import { memo, useCallback, useEffect, useState } from 'react';
 
 import DialogModal from '@templates/DialogModal';
 
-export type ImgResult = 'success' | 'error' | null;
+export type recognitionResult = {
+  state?: 'success' | 'failed' | 'error';
+  category?: string;
+  tag?: string;
+  color?: string;
+  material?: string;
+};
 
 type Props = {
   isLoading: boolean;
-  resultType: ImgResult;
+  result: recognitionResult;
 };
 
 function ImgResultModal(modalProps: Props) {
-  const { isLoading, resultType } = modalProps;
+  const { isLoading, result } = modalProps;
+  const { state, tag, color, material, category } = result;
   const [dialogOpen, setDialogOpen] = useState(false);
   const titleText = `이미지 인식에 ${
-    resultType === 'success' ? '성공' : '실패'
+    state === 'failed' ? '실패' : '성공'
   }했습니다.`;
 
-  const contentText =
-    resultType === 'success'
-      ? '스타일 정보(태그, 컬러, 소재) 아이템 기본 정보(카테고리)가 성공적으로 인식되었습니다.\n\n인식 결과가 예상과 다르다면 입력 항목을 직접 수정해주세요.'
-      : '이미지 인식에 성공하는 경우 스타일 정보(태그, 컬러, 소재) 아이템 기본 정보(카테고리)를 자동으로 채워줍니다.\n\n이미지 인식을 원하는 경우 다른 사진을 올려주세요. 혹은 입력 항목을 직접 수정해주세요.';
+  const failText =
+    '이미지 인식에 성공하는 경우 스타일 정보(태그, 컬러, 소재) 아이템 기본 정보(카테고리)를 자동으로 채워줍니다.\n\n이미지 인식을 원하는 경우 다른 사진을 올려주세요. 혹은 입력 항목을 직접 수정해주세요.';
+  const successText = `스타일 정보(태그: ${tag}, 컬러: ${color}, 소재: ${material})\n 아이템 기본 정보(카테고리: ${category})가 성공적으로 인식되었습니다.\n\n인식 결과가 예상과 다르다면 입력 항목을 직접 수정해주세요.`;
+  const contentText = state === 'success' ? successText : failText;
 
   useEffect(() => {
-    if (!isLoading && resultType) setDialogOpen(true);
-  }, [resultType, isLoading]);
+    if (!isLoading && state && state !== 'error') setDialogOpen(true);
+  }, [result, isLoading, state]);
 
   const handleClick = useCallback(() => setDialogOpen(false), []);
 

--- a/src/components/Upload/organisms/ImgResultModal/index.tsx
+++ b/src/components/Upload/organisms/ImgResultModal/index.tsx
@@ -1,14 +1,10 @@
 import { memo, useCallback, useEffect, useState } from 'react';
 
+import { recognitionResult } from '#types/upload';
 import DialogModal from '@templates/DialogModal';
 
-export type recognitionResult = {
-  state?: 'success' | 'failed' | 'error';
-  category?: string;
-  tag?: string;
-  color?: string;
-  material?: string;
-};
+import FailText from '../../atoms/FailText';
+import SuccessText from '../../atoms/SuccessText';
 
 type Props = {
   isLoading: boolean;
@@ -23,10 +19,12 @@ function ImgResultModal(modalProps: Props) {
     state === 'failed' ? '실패' : '성공'
   }했습니다.`;
 
-  const failText =
-    '이미지 인식에 성공하는 경우 스타일 정보(태그, 컬러, 소재) 아이템 기본 정보(카테고리)를 자동으로 채워줍니다.\n\n이미지 인식을 원하는 경우 다른 사진을 올려주세요. 혹은 입력 항목을 직접 수정해주세요.';
-  const successText = `스타일 정보(태그: ${tag}, 컬러: ${color}, 소재: ${material})\n 아이템 기본 정보(카테고리: ${category})가 성공적으로 인식되었습니다.\n\n인식 결과가 예상과 다르다면 입력 항목을 직접 수정해주세요.`;
-  const contentText = state === 'success' ? successText : failText;
+  const contentText =
+    state === 'success' ? (
+      <SuccessText {...{ tag, color, material, category }} />
+    ) : (
+      <FailText />
+    );
 
   useEffect(() => {
     if (!isLoading && state && state !== 'error') setDialogOpen(true);

--- a/src/components/Upload/organisms/ImgUpload/ImgUploadView.tsx
+++ b/src/components/Upload/organisms/ImgUpload/ImgUploadView.tsx
@@ -1,13 +1,14 @@
 import React, { memo } from 'react';
 
 import { ImgList } from '#types/storeType/upload';
+import { recognitionResult } from '#types/upload';
 import ErrorMsg from '@atoms/ErrorMsg';
 import Loading from '@atoms/Loading';
 import classnames from 'classnames';
 import ImgCard from 'src/components/Upload/molecules/ImgCard';
 import ImgUploadBtn from 'src/components/Upload/molecules/ImgUploadBtn';
 
-import ImgResultModal, { recognitionResult } from '../ImgResultModal';
+import ImgResultModal from '../ImgResultModal';
 import $ from './style.module.scss';
 
 type Props = {

--- a/src/components/Upload/organisms/ImgUpload/ImgUploadView.tsx
+++ b/src/components/Upload/organisms/ImgUpload/ImgUploadView.tsx
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 import ImgCard from 'src/components/Upload/molecules/ImgCard';
 import ImgUploadBtn from 'src/components/Upload/molecules/ImgUploadBtn';
 
-import ImgResultModal, { ImgResult } from '../ImgResultModal';
+import ImgResultModal, { recognitionResult } from '../ImgResultModal';
 import $ from './style.module.scss';
 
 type Props = {
@@ -15,7 +15,7 @@ type Props = {
   uploadRef: React.RefObject<HTMLDivElement>;
   inputRef: React.RefObject<HTMLInputElement>;
   state: ImgList[];
-  imgResult: ImgResult;
+  imgResult: recognitionResult;
   onUploadClick: () => void;
   onUploadImg: (e: React.ChangeEvent) => void;
   remove: (removeId: number) => void;
@@ -52,7 +52,7 @@ function ImgUploadView(viewProps: Props) {
           />
         </>
       )}
-      <ImgResultModal resultType={imgResult} {...{ isLoading }} />
+      <ImgResultModal result={imgResult} {...{ isLoading }} />
     </article>
   );
 }

--- a/src/components/Upload/organisms/ImgUpload/index.tsx
+++ b/src/components/Upload/organisms/ImgUpload/index.tsx
@@ -6,14 +6,13 @@ import {
   UpdateUpload,
   UploadStoreState,
 } from '#types/storeType/upload';
+import { recognitionResult } from '#types/upload';
 import { getCategoryIds } from 'src/api/category';
 import { useImgUpload } from 'src/hooks/api/upload';
 import useDragScroll from 'src/hooks/useDragScroll';
-import { toastError } from 'src/utils/toaster';
 
-import { recognitionResult } from '../ImgResultModal';
 import ImgUploadView from './ImgUploadView';
-import { imageList } from './utils';
+import { getFormData, imageList } from './utils';
 
 type Props = {
   isImgValid: boolean;
@@ -40,48 +39,35 @@ function ImgUpload(imgProps: Props) {
 
   const onUploadImg = useCallback(
     (e: React.ChangeEvent) => {
-      const formData = new FormData();
-      if (e.type === 'change' && 'files' in e.target) {
-        const {
-          target: { files },
-        } = e;
-        if (files) {
-          const filesArr: File[] = Array.from(files);
-          if (filesArr.length > 10) {
-            filesArr.splice(10);
-            toastError({ message: '이미지는 최대 10개까지 올릴 수 있습니다.' });
-          }
-          filesArr.forEach((file: File) => {
-            formData.append('files', file);
-          });
-          mutate(formData, {
-            onSuccess: ({ error, attribute, image }) => {
-              const images = imageList(image);
-              if (image.length) imgUpload(images);
-              if (error) {
-                if (image.length) setImgResult({ state: 'failed' });
-                else setImgResult({ state: 'error' });
-                return;
-              }
-              const { style: tag, material, color } = attribute;
-              const { gender, mainCategory, subCategory } = attribute;
-              const nameArr = [gender, mainCategory, subCategory];
-              const category = `${gender} > ${mainCategory} > ${subCategory}`;
-              const categoryIds = getCategoryIds(categoryData, nameArr);
-              setImgResult({
-                state: 'success',
-                category,
-                tag,
-                color: color.join(', '),
-                material,
-              });
-              updateArr(categoryIds, 'basicInfo', 'category');
-              updateArr(color, 'style', 'color');
-              onChange(tag, 'style', 'tag');
-              onChange(material, 'style', 'material');
-            },
-          });
-        }
+      const formData = getFormData(e);
+      if (formData) {
+        mutate(formData, {
+          onSuccess: ({ error, attribute, image }) => {
+            const images = imageList(image);
+            if (image.length) imgUpload(images);
+            if (error) {
+              if (image.length) setImgResult({ state: 'failed' });
+              else setImgResult({ state: 'error' });
+              return;
+            }
+            const { style: tag, material, color } = attribute;
+            const { gender, mainCategory, subCategory } = attribute;
+            const nameArr = [gender, mainCategory, subCategory];
+            const category = `${gender} > ${mainCategory} > ${subCategory}`;
+            const categoryIds = getCategoryIds(categoryData, nameArr);
+            setImgResult({
+              state: 'success',
+              category,
+              tag,
+              color: color.join(', '),
+              material,
+            });
+            updateArr(categoryIds, 'basicInfo', 'category');
+            updateArr(color, 'style', 'color');
+            onChange(tag, 'style', 'tag');
+            onChange(material, 'style', 'material');
+          },
+        });
       }
     },
     [mutate, categoryData, imgUpload, updateArr, onChange],

--- a/src/components/Upload/organisms/ImgUpload/utils.ts
+++ b/src/components/Upload/organisms/ImgUpload/utils.ts
@@ -1,3 +1,5 @@
+import { toastError } from 'src/utils/toaster';
+
 export const imageList = (imgList: string[]) =>
   imgList.map((img, idx) => {
     return {
@@ -5,3 +7,24 @@ export const imageList = (imgList: string[]) =>
       src: img,
     };
   });
+
+export const getFormData = (e: React.ChangeEvent) => {
+  if (e.type === 'change' && 'files' in e.target) {
+    const formData = new FormData();
+    const {
+      target: { files },
+    } = e;
+    if (files) {
+      const filesArr: File[] = Array.from(files);
+      if (filesArr.length > 10) {
+        filesArr.splice(10);
+        toastError({ message: '이미지는 최대 10개까지 올릴 수 있습니다.' });
+      }
+      filesArr.forEach((file: File) => {
+        formData.append('files', file);
+      });
+      return formData;
+    }
+  }
+  return null;
+};

--- a/src/components/shared/atoms/ProfileImg/index.tsx
+++ b/src/components/shared/atoms/ProfileImg/index.tsx
@@ -9,8 +9,8 @@ import $ from './style.module.scss';
 export default function ProfileImg({
   className,
   style,
-  width = 44,
-  height = 44,
+  width = 36,
+  height = 36,
   src,
   alt,
 }: DefaultProps & ImgProps) {

--- a/src/components/shared/atoms/ProfileImg/style.module.scss
+++ b/src/components/shared/atoms/ProfileImg/style.module.scss
@@ -1,20 +1,8 @@
 .profile-img {
-  width: 44px;
-  height: 44px;
   display: flex;
   @include border(border, 50%, $gray-280);
-  @include mobile() {
-    width: 36px;
-    height: 36px;
-  }
   img {
-    width: 44px;
-    height: 44px;
     border-radius: 50%;
     object-fit: contain;
-    @include mobile() {
-      width: 36px;
-      height: 36px;
-    }
   }
 }

--- a/src/components/shared/molecules/Profile/index.tsx
+++ b/src/components/shared/molecules/Profile/index.tsx
@@ -31,7 +31,7 @@ export default function Profile(profileProps: Props) {
         className={$['profile-box']}
         onClick={handleProfileClick}
       >
-        <ProfileImg src={profileImg} alt={nickname} />
+        <ProfileImg src={profileImg} alt={nickname} width={44} height={44} />
         <span className={$.nickname}>{nickname}</span>
       </button>
     </div>

--- a/src/components/shared/templates/DialogModal/index.tsx
+++ b/src/components/shared/templates/DialogModal/index.tsx
@@ -15,7 +15,7 @@ type Props = {
   isOpen: boolean;
   isVerticalBtn?: boolean;
   title?: string;
-  content?: string;
+  content?: string | JSX.Element;
   emphasisContent?: string;
   clickText?: string;
   cancelText?: string;

--- a/src/constants/queryString/index.ts
+++ b/src/constants/queryString/index.ts
@@ -2,15 +2,15 @@ import { orderData } from '..';
 
 export const queries: readonly (keyof Omit<req.ShopFeed, 'page' | 'size'>)[] = [
   'category',
-  'hide_sold',
+  'hideSold',
   'order',
   'style',
-  'price_goe',
-  'price_loe',
+  'priceGoe',
+  'priceLoe',
   'color',
   'fit',
   'length',
-  'clothes_size',
+  'clothesSize',
 ];
 
 export const queryData: [keyof Omit<req.ShopFeed, 'page' | 'size'>, string?][] =
@@ -21,7 +21,7 @@ export const queryData: [keyof Omit<req.ShopFeed, 'page' | 'size'>, string?][] =
 export const searchQueries: readonly (keyof Omit<
   req.ShopFeed,
   'page' | 'size'
->)[] = ['value', 'hide_sold', 'order'];
+>)[] = ['value', 'hideSold', 'order'];
 
 export const searchQueryData: [
   keyof Omit<req.ShopFeed, 'page' | 'size'>,

--- a/src/pages/info/basic/style.module.scss
+++ b/src/pages/info/basic/style.module.scss
@@ -1,5 +1,5 @@
 .basic-info-layout {
-  padding-bottom: 80px;
+  padding-bottom: 110px;
 }
 
 .height-input {

--- a/src/pages/info/color/style.module.scss
+++ b/src/pages/info/color/style.module.scss
@@ -1,3 +1,3 @@
 .color-info-layout {
-  padding-bottom: 80px;
+  padding-bottom: 110px;
 }

--- a/src/pages/info/style/style.module.scss
+++ b/src/pages/info/style/style.module.scss
@@ -1,5 +1,5 @@
 .style-info-layout {
-  padding-bottom: 80px;
+  padding-bottom: 110px;
 }
 
 .style-info {

--- a/src/pages/mypage/setting/user.tsx
+++ b/src/pages/mypage/setting/user.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react';
 
-import { ISR_5MIN } from '@constants/api';
 import { queryKey } from '@constants/react-query';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { GetServerSidePropsContext } from 'next';
 
 import { ReactElement } from 'react';
@@ -20,8 +19,8 @@ import { getQueriesArr, getQueryStringObj } from 'src/utils';
 
 export const getServerSideProps = withGetServerSideProps(
   async ({ query }: GetServerSidePropsContext) => {
-    const { value, hide_sold, order } = query;
-    const queryArr = [value, hide_sold, order];
+    const { value, hideSold, order } = query;
+    const queryArr = [value, hideSold, order];
 
     const queryObj = getQueriesArr(searchQueryData, queryArr);
     const queryStringObj = getQueryStringObj(queryObj);
@@ -49,7 +48,7 @@ export const getServerSideProps = withGetServerSideProps(
 
 function SearchPage() {
   const queryStringObj = useMultipleSearch(searchQueryData, searchQueries);
-  const { value, hide_sold, order } = queryStringObj;
+  const { value, hideSold, order } = queryStringObj;
 
   const isMounted = useMounted();
 
@@ -65,7 +64,7 @@ function SearchPage() {
       <SearchHeader
         {...{
           searchWord: value,
-          hideSoldQuery: hide_sold,
+          hideSoldQuery: hideSold,
           orderQuery: order,
         }}
       />

--- a/src/pages/shop/index.tsx
+++ b/src/pages/shop/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { GetServerSidePropsContext } from 'next';
 
 import { ReactElement } from 'react';
@@ -23,10 +22,10 @@ import { judgeCategoryId } from 'src/utils/shop.utils';
 
 export const getServerSideProps = withGetServerSideProps(
   async ({ query }: GetServerSidePropsContext) => {
-    const { category, hide_sold, order, style } = query;
-    const { price_goe, price_loe, color, fit, length, clothes_size } = query;
-    const arr1 = [category, hide_sold, order, style]; // TODO: obj로 변경
-    const arr2 = [price_goe, price_loe, color, fit, length, clothes_size];
+    const { category, hideSold, order, style } = query;
+    const { priceGoe, priceLoe, color, fit, length, clothesSize } = query;
+    const arr1 = [category, hideSold, order, style]; // TODO: obj로 변경
+    const arr2 = [priceGoe, priceLoe, color, fit, length, clothesSize];
     const queryArr = [...arr1, ...arr2];
 
     const queryObj = getQueriesArr(queryData, queryArr);
@@ -58,7 +57,7 @@ export const getServerSideProps = withGetServerSideProps(
 function Shop() {
   const data = useCategoryTree(false)?.data;
   const queryObj = useMultipleSearch(queryData, queries);
-  const { category, hide_sold, order } = queryObj;
+  const { category, hideSold, order } = queryObj;
 
   if (!data) return null;
 
@@ -82,7 +81,7 @@ function Shop() {
     genderQuery,
     categoryQuery,
     orderQuery: order,
-    hideSoldQuery: hide_sold,
+    hideSoldQuery: hideSold,
     genderSelectMenu,
     selectData,
     breadCrumb,

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -8,7 +8,6 @@ import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';
 import UploadTemplate from '@templates/UploadTemplate';
 import { getCategory } from 'src/api/category';
-import { withGetServerSideProps } from 'src/api/core/withGetServerSideProps';
 import { getStaticData } from 'src/api/staticData';
 import { useUploadStore } from 'src/store/upload/useUploadStore';
 import { toastError } from 'src/utils/toaster';

--- a/src/types/apiTypes/shop.d.ts
+++ b/src/types/apiTypes/shop.d.ts
@@ -32,13 +32,13 @@ declare namespace req {
     value?: string;
     category?: string;
     order?: string; // TODO: order는 필수값으로 수정할 것
-    hide_sold?: string;
+    hideSold?: string;
     style?: string;
-    price_goe?: string;
-    price_loe?: string;
+    priceGoe?: string;
+    priceLoe?: string;
     color?: string;
     fit?: string;
     length?: string;
-    clothes_size?: string;
+    clothesSize?: string;
   };
 }

--- a/src/types/upload.ts
+++ b/src/types/upload.ts
@@ -1,0 +1,7 @@
+export type recognitionResult = {
+  state?: 'success' | 'failed' | 'error';
+  category?: string;
+  tag?: string;
+  color?: string;
+  material?: string;
+};


### PR DESCRIPTION
## 💡 이슈
resolve #136 

## 🤩 개요
이미지 업로드 결과 모달에 보여주기

## 🧑‍💻 작업 사항
### 이미지 업로드 결과 모달에 보여주기
formData를 받는 로직은 컴포넌트 관심사와 분리할 필요가 있어 보여 util에 따로 분리했습니다. 또한, 서비스 상에서 이미지 업로드 결과의 상태는 `인식 성공`, `인식 실패`, `업로드 실패` 3가지인데 이전에 `성공`, `실패` 두 가지로만 구분하여

인식 실패 -> 업로드 실패의 과정에서 업로드 실패일 때는 모달이 나타나지 않아야 하는데 나타나는 이슈가 있었습니다. 그리하여 상태를 `success`, 'failed', 'error'로 구분하여 `success`, 'failed'일때만 모달이 나타나도록 구현했습니다.

UI에서 변경사항이 있습니다. 인식 결과를 모달에 나타내어 사용자에게 알려주었습니다. `알려주지 않으면 인식되는지 모를 수 있겠다`는 생각이었습니다. 또한, 기존에는 string으로 사용했지만 component로 따로 사용하였습니다. 이유는 `인식 결과에 대한 스타일을 부여`하는 것이 좋겠다는 생각이었습니다.

### shop query string 수정하기
이전에 서버와 snake_case로 컨벤션을 맞췄는데 필터 기능이 잘 되지 않아 여쭤봤더니 서버 코드가 caMelCase로 되어 있었습니다. 그리하여 caMelCase로 바꾸었습니다.

### ProfileImg width, height 버그 수정
shop detail 페이지에서 "판매자의 한마디"의 사용자 프로필 부분이 깨지는 버그가 있었습니다. 이전에 사용자 정보 수정 페이지에서 해당 컴포넌트를 사용하다 width, height 속성에 default값을 주었더니 버그가 발생했습니다. 그리하여 서비스 디자인 상 최소 값인 36으로(44 -> 36)으로 디폴트 값을 수정했고 그 이상 값이 필요한 경우 prop을 사용하는 것으로 결정했습니다.

### preference, 사용자 정보 수정 padding-bottom 부여하기
모바일 화면에서 보게 되면 padding-bottom이 없는 버그가 발생함을 인지했고 해결했습니다.

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.
<img src="https://user-images.githubusercontent.com/62797441/199793151-453956cf-38d1-4004-8f3e-9e37c5b1b6c1.png" width=300 />

