### PR TITLE
[feat] 업로드 및 preference 화면 보이기 전에 인증 요청하기

### DIFF
--- a/src/api/core/errorInterceptor.ts
+++ b/src/api/core/errorInterceptor.ts
@@ -1,4 +1,4 @@
-import { USER_NOT_EXISTED } from '@constants/api';
+import { PRODUCT_NOT_FOUND_MSG, USER_NOT_EXISTED } from '@constants/api';
 import { AxiosError } from 'axios';
 
 import {
@@ -19,7 +19,7 @@ export default function ErrorInterceptor(err: AxiosError): AxiosError {
       throw new ForbiddenError(status, message);
     } else if (status === 401) {
       throw new AuthError(status, message);
-    } else if (status === 400 && message === '해당 상품이 존재하지 않습니다') {
+    } else if (status === 400 && message === PRODUCT_NOT_FOUND_MSG) {
       throw new NotFoundError(status, message);
     } else if (status === 400 && code === USER_NOT_EXISTED) {
       throw new ForbiddenError(status, message);

--- a/src/api/core/index.ts
+++ b/src/api/core/index.ts
@@ -4,7 +4,6 @@ import setInterceptors from './interceptors';
 
 const AiAxios = axios.create({
   baseURL: process.env.AI_API_URL,
-  timeout: 20000,
   headers: {
     'Content-type': 'multipart/form-data',
   },

--- a/src/api/core/index.ts
+++ b/src/api/core/index.ts
@@ -1,31 +1,6 @@
-/* eslint-disable no-param-reassign */
-import {
-  ACCESSTOKEN,
-  ACCESSTOKEN_EXPIRED,
-  HTTP_METHOD,
-  TOKEN_REFRESH,
-} from '@constants/api';
-import axios, {
-  AxiosError,
-  AxiosRequestConfig,
-  AxiosResponse,
-  AxiosInstance,
-  Method,
-} from 'axios';
-import { getAccessToken, setAccessToken } from 'src/utils/auth';
+import axios from 'axios';
 
-import { ForbiddenError, isAxiosError } from './error';
-import ErrorInterceptor from './errorInterceptor';
-
-export const axiosInstance = axios.create({
-  baseURL: process.env.API_URL,
-  timeout: 5000,
-  withCredentials: true,
-  headers: {
-    'Content-type': 'application/json',
-    [ACCESSTOKEN]: getAccessToken(),
-  },
-});
+import setInterceptors from './interceptors';
 
 const AiAxios = axios.create({
   baseURL: process.env.AI_API_URL,
@@ -35,68 +10,17 @@ const AiAxios = axios.create({
   },
 });
 
-const handleRequest = (config: AxiosRequestConfig): AxiosRequestConfig => {
-  return {
-    ...config,
+function createInstance() {
+  const axiosInstance = axios.create({
+    baseURL: process.env.API_URL,
+    timeout: 5000,
+    withCredentials: true,
     headers: {
-      ...config.headers,
+      'Content-type': 'application/json',
     },
-  };
-};
-
-const handleResponse = <T>(response: AxiosResponse<T>) => {
-  return response.data;
-};
-
-export const refreshAccessToken = async (err: AxiosError) => {
-  try {
-    const response = await axiosInstance.get<res.reissue>(TOKEN_REFRESH);
-    const {
-      data: { accessToken },
-    } = response.data;
-    if (err.config.headers) {
-      err.config.headers[ACCESSTOKEN] = accessToken;
-    }
-    setAccessToken(accessToken);
-    axiosInstance.defaults.headers[ACCESSTOKEN] = accessToken;
-    const res = await axiosInstance.request(err.config);
-    return Promise.resolve(handleResponse(res));
-  } catch (error) {
-    throw new ForbiddenError(403);
-  }
-};
-
-const createApiMethod = (_axiosInstance: AxiosInstance, method: Method) => {
-  return (
-    url: AxiosRequestConfig['url'],
-    data?: AxiosRequestConfig['data'],
-    config?: Omit<AxiosRequestConfig, 'url'>,
-  ): Promise<any> => {
-    return _axiosInstance({
-      ...handleRequest({ url, data, ...config }),
-      method,
-    })
-      .then((res) => {
-        return Promise.resolve(handleResponse(res));
-      })
-      .catch((err) => {
-        if (isAxiosError<res.error>(err) && err.response) {
-          const { status, code } = err.response.data;
-          if (status === 403 && code === ACCESSTOKEN_EXPIRED) {
-            return refreshAccessToken(err);
-          }
-        }
-        return Promise.reject(ErrorInterceptor(err));
-      });
-  };
-};
-
-const Axios = {
-  get: createApiMethod(axiosInstance, HTTP_METHOD.GET),
-  post: createApiMethod(axiosInstance, HTTP_METHOD.POST),
-  patch: createApiMethod(axiosInstance, HTTP_METHOD.PATCH),
-  put: createApiMethod(axiosInstance, HTTP_METHOD.PUT),
-  delete: createApiMethod(axiosInstance, HTTP_METHOD.DELETE),
-};
+  });
+  return setInterceptors(axiosInstance);
+}
+const Axios = createInstance();
 
 export { Axios, AiAxios };

--- a/src/api/core/interceptors.ts
+++ b/src/api/core/interceptors.ts
@@ -1,0 +1,41 @@
+/* eslint-disable no-param-reassign */
+import { ACCESSTOKEN, ACCESSTOKEN_EXPIRED } from '@constants/api';
+import { AxiosInstance } from 'axios';
+import { getAccessToken } from 'src/utils/auth';
+
+import { isAxiosError } from './error';
+import ErrorInterceptor from './errorInterceptor';
+import { refreshAccessToken } from './refresh';
+
+function setInterceptors(instance: AxiosInstance) {
+  instance.interceptors.request.use(
+    (config) => {
+      if (typeof window !== 'undefined' && config.headers) {
+        config.headers[ACCESSTOKEN] = getAccessToken();
+      }
+      return config;
+    },
+    (error) => {
+      return Promise.reject(error);
+    },
+  );
+
+  instance.interceptors.response.use(
+    (res) => {
+      return Promise.resolve(res.data);
+    },
+    (err) => {
+      if (isAxiosError<res.error>(err) && err.response) {
+        const { status, code } = err.response.data;
+        if (status === 403 && code === ACCESSTOKEN_EXPIRED) {
+          return refreshAccessToken(err, instance);
+        }
+      }
+      return Promise.reject(ErrorInterceptor(err));
+    },
+  );
+
+  return instance;
+}
+
+export default setInterceptors;

--- a/src/api/core/refresh.ts
+++ b/src/api/core/refresh.ts
@@ -1,0 +1,28 @@
+/* eslint-disable no-param-reassign */
+import { ACCESSTOKEN, TOKEN_REFRESH } from '@constants/api';
+import { AxiosError, AxiosInstance } from 'axios';
+import { setAccessToken } from 'src/utils/auth';
+
+import { ForbiddenError } from './error';
+
+export const refreshAccessToken = async (
+  err: AxiosError,
+  instance: AxiosInstance,
+) => {
+  try {
+    const response = await instance.get<res.reissue>(TOKEN_REFRESH);
+    const {
+      data: { accessToken },
+    } = response.data;
+    if (err.config.headers) {
+      err.config.headers[ACCESSTOKEN] = accessToken;
+    }
+    setAccessToken(accessToken);
+    instance.defaults.headers[ACCESSTOKEN] = accessToken;
+    response.headers['set-cookie'] = [`${ACCESSTOKEN}=${accessToken}`];
+    const res = await instance.request(err.config);
+    return Promise.resolve(res.data);
+  } catch (error) {
+    throw new ForbiddenError(403);
+  }
+};

--- a/src/api/login/index.ts
+++ b/src/api/login/index.ts
@@ -21,3 +21,8 @@ export const logout = async () => {
     return err;
   }
 };
+
+export const authTest = async () => {
+  const response = await Axios.get('/auth-testing');
+  return response;
+};

--- a/src/constants/api/index.ts
+++ b/src/constants/api/index.ts
@@ -10,6 +10,7 @@ export const ACCESSTOKEN = 'x-access-token';
 
 export const ACCESSTOKEN_EXPIRED = 'TOKEN_EXPIRED';
 export const USER_NOT_EXISTED = 'USER_NOT_EXISTED';
+export const PRODUCT_NOT_FOUND_MSG = '해당 상품이 존재하지 않습니다';
 
 export const TOKEN_REFRESH = 'api/auth/reissue';
 

--- a/src/hooks/api/core/index.ts
+++ b/src/hooks/api/core/index.ts
@@ -13,9 +13,7 @@ import type {
 } from '@tanstack/react-query';
 import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
-import { isInstanceOfAPIError } from 'src/api/core/error';
-
-import { toastError } from '../../../utils/toaster';
+import { errorHandler } from 'src/utils/errorHandler';
 
 export function useCoreQuery<T, U = null>(
   keyName: QueryKey,
@@ -28,17 +26,7 @@ export function useCoreQuery<T, U = null>(
   const router = useRouter();
   return useQuery(keyName, query, {
     onError: (err) => {
-      if (isInstanceOfAPIError(err)) {
-        const { redirectUrl, notFound, status } = err;
-        if (notFound) {
-          return router.push('/404');
-        }
-        if (status === 401 || status === 403)
-          toastError({ message: '다시 로그인해주세요.' });
-        if (redirectUrl) {
-          router.push(redirectUrl);
-        }
-      }
+      errorHandler(err, router);
       return console.error(err);
     },
     ...options,
@@ -52,17 +40,7 @@ export function useCoreMutation<T, U>(
   const router = useRouter();
   return useMutation(mutation, {
     onError: (err) => {
-      if (isInstanceOfAPIError(err)) {
-        const { redirectUrl, notFound, status } = err;
-        if (notFound) {
-          return router.push('/404');
-        }
-        if (status === 401 || status === 403)
-          toastError({ message: '다시 로그인해주세요.' });
-        if (redirectUrl) {
-          router.push(redirectUrl);
-        }
-      }
+      errorHandler(err, router);
       return console.error(err);
     },
     ...options,

--- a/src/hooks/api/core/index.ts
+++ b/src/hooks/api/core/index.ts
@@ -1,3 +1,5 @@
+import { useRouter } from 'next/router';
+
 import type {
   MutationFunction,
   QueryFunction,
@@ -11,6 +13,9 @@ import type {
 } from '@tanstack/react-query';
 import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
+import { isInstanceOfAPIError } from 'src/api/core/error';
+
+import { toastError } from '../../../utils/toaster';
 
 export function useCoreQuery<T, U = null>(
   keyName: QueryKey,
@@ -20,8 +25,20 @@ export function useCoreQuery<T, U = null>(
     'queryKey' | 'queryFn'
   >,
 ): UseQueryResult<U extends null ? T : U, AxiosError> {
+  const router = useRouter();
   return useQuery(keyName, query, {
     onError: (err) => {
+      if (isInstanceOfAPIError(err)) {
+        const { redirectUrl, notFound, status } = err;
+        if (notFound) {
+          return router.push('/404');
+        }
+        if (status === 401 || status === 403)
+          toastError({ message: '다시 로그인해주세요.' });
+        if (redirectUrl) {
+          router.push(redirectUrl);
+        }
+      }
       return console.error(err);
     },
     ...options,
@@ -32,8 +49,20 @@ export function useCoreMutation<T, U>(
   mutation: MutationFunction<T, U>,
   options?: Omit<UseMutationOptions<T, AxiosError, U>, 'mutationKey'>,
 ): UseMutationResult<T, AxiosError, U> {
+  const router = useRouter();
   return useMutation(mutation, {
     onError: (err) => {
+      if (isInstanceOfAPIError(err)) {
+        const { redirectUrl, notFound, status } = err;
+        if (notFound) {
+          return router.push('/404');
+        }
+        if (status === 401 || status === 403)
+          toastError({ message: '다시 로그인해주세요.' });
+        if (redirectUrl) {
+          router.push(redirectUrl);
+        }
+      }
       return console.error(err);
     },
     ...options,

--- a/src/hooks/api/login/index.ts
+++ b/src/hooks/api/login/index.ts
@@ -1,10 +1,10 @@
 import { useRouter } from 'next/router';
 
-import { postAuthToken } from 'src/api/login';
+import { postAuthToken, authTest } from 'src/api/login';
 import { setAccessToken } from 'src/utils/auth';
 import { toastError, toastSuccess } from 'src/utils/toaster';
 
-import { useCoreMutation } from '../core';
+import { useCoreMutation, useCoreQuery } from '../core';
 
 export const usePostAuthToken = () => {
   const router = useRouter();
@@ -19,6 +19,17 @@ export const usePostAuthToken = () => {
     },
     onError: () => {
       router.back();
+      toastError({ message: '다시 로그인해주세요.' });
+    },
+  });
+};
+
+export const useAuthTest = () => {
+  const router = useRouter();
+  return useCoreQuery(['auth-test'], () => authTest(), {
+    retry: false,
+    onError: () => {
+      router.push('/login');
       toastError({ message: '다시 로그인해주세요.' });
     },
   });

--- a/src/hooks/api/login/index.ts
+++ b/src/hooks/api/login/index.ts
@@ -17,20 +17,15 @@ export const usePostAuthToken = () => {
       if (hasPreference) router.push('/shop');
       else router.push('/info/basic');
     },
-    onError: () => {
-      router.back();
-      toastError({ message: '다시 로그인해주세요.' });
+    onSettled: (_, error) => {
+      if (error) {
+        router.back();
+        toastError({ message: '다시 로그인해주세요.' });
+      }
     },
   });
 };
 
 export const useAuthTest = () => {
-  const router = useRouter();
-  return useCoreQuery(['auth-test'], () => authTest(), {
-    retry: false,
-    onError: () => {
-      router.push('/login');
-      toastError({ message: '다시 로그인해주세요.' });
-    },
-  });
+  return useCoreQuery(['auth-test'], () => authTest(), {});
 };

--- a/src/hooks/api/preference/index.ts
+++ b/src/hooks/api/preference/index.ts
@@ -15,7 +15,7 @@ export function usePostPreference() {
       toastSuccess({ message: '정보를 성공적으로 입력했습니다.' });
       router.push('/shop');
     },
-    onError: (error) => {
+    onSettled: (_, error) => {
       if (isAxiosError<res.error>(error) && error.response) {
         toastError({ message: '에러가 발생했습니다.' });
       }
@@ -25,7 +25,7 @@ export function usePostPreference() {
 
 export function useStyleImgs() {
   const response = useCoreQuery(queryKey.styleImgs, getStyleImgs, {
-    onError: (error) => {
+    onSettled: (error) => {
       if (isAxiosError<res.error>(error) && error.response) {
         const { message } = error.response.data;
         toastError({ message });

--- a/src/hooks/api/product/index.ts
+++ b/src/hooks/api/product/index.ts
@@ -24,7 +24,7 @@ export function useDeleteProduct(id: string) {
       queryClient.invalidateQueries(['productItemList']);
       toastSuccess({ message: '상품을 삭제했습니다.' });
     },
-    onError: (err) => {
+    onSettled: (_, err) => {
       if (isAxiosError<res.error>(err) && !!err.response) {
         const { message } = err.response.data;
         toastError({ message });

--- a/src/hooks/api/profile/index.ts
+++ b/src/hooks/api/profile/index.ts
@@ -23,8 +23,8 @@ export function useUpdateMyInfo() {
       toastSuccess({ message: '성공적으로 업데이트했습니다.' });
       router.replace('/mypage');
     },
-    onError: () => {
-      toastError({ message: '업데이트에 실패했습니다.' });
+    onSettled: (_, err) => {
+      if (err) toastError({ message: '업데이트에 실패했습니다.' });
     },
   });
 }

--- a/src/hooks/api/upload/index.ts
+++ b/src/hooks/api/upload/index.ts
@@ -26,8 +26,8 @@ export const useImgUpload = () => {
         toastError({ message: '이미지 인식을 실패했습니다.' });
       }
     },
-    onError: () => {
-      toastError({ message: '이미지 업로드를 실패했습니다.' });
+    onSettled: (_, err) => {
+      if (err) toastError({ message: '이미지 업로드를 실패했습니다.' });
     },
   });
 };
@@ -44,7 +44,7 @@ export const useProductUpload = () => {
       clearUpload();
       toastSuccess({ message: '상품 등록에 성공했습니다.' });
     },
-    onError: (err) => {
+    onSettled: (_, err) => {
       if (isAxiosError<res.error>(err) && !!err.response) {
         const { message } = err.response.data;
         toastError({ message });
@@ -61,7 +61,7 @@ export function useUpdateProduct(id: string) {
       queryClient.invalidateQueries(['productItemList']);
       toastSuccess({ message: '상품을 수정했습니다.' });
     },
-    onError: (err) => {
+    onSettled: (_, err) => {
       if (isAxiosError<res.error>(err) && !!err.response) {
         const { message } = err.response.data;
         toastError({ message });
@@ -72,7 +72,15 @@ export function useUpdateProduct(id: string) {
 }
 
 export const useUploadedProduct = (id: string) => {
-  return useCoreQuery(queryKey.uploadedProduct(id), () =>
-    getUploadedProduct(id),
+  return useCoreQuery(
+    queryKey.uploadedProduct(id),
+    () => getUploadedProduct(id),
+    {
+      onSettled: (_, err) => {
+        if (isAxiosError<res.error>(err) && err.response) {
+          toastError({ message: err.response.data.message });
+        }
+      },
+    },
   );
 };

--- a/src/hooks/api/upload/index.ts
+++ b/src/hooks/api/upload/index.ts
@@ -56,7 +56,7 @@ export const useProductUpload = () => {
 export function useUpdateProduct(id: string) {
   const response = useCoreMutation(updateProductDetail, {
     onSuccess: ({ data }) => {
-      router.push(`/shop/${data}`);
+      router.replace(`/shop/${data}`);
       queryClient.invalidateQueries(queryKey.productDetail(id));
       queryClient.invalidateQueries(['productItemList']);
       toastSuccess({ message: '상품을 수정했습니다.' });

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -13,7 +13,7 @@ import {
 } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import '../styles/globals.scss';
-import { axiosInstance } from 'src/api/core';
+import { Axios } from 'src/api/core';
 import { useMounted, useWindowResize } from 'src/hooks';
 import { getSSRAccessToken } from 'src/utils/auth';
 
@@ -77,10 +77,10 @@ MyApp.getInitialProps = async (context: AppContext) => {
   let pageProps = {};
   const cookie = ctx.req?.headers.cookie || '';
   const token = getSSRAccessToken(ctx);
-  axiosInstance.defaults.headers.Cookie = '';
-  axiosInstance.defaults.headers[ACCESSTOKEN] = token;
+  Axios.defaults.headers.Cookie = '';
+  Axios.defaults.headers[ACCESSTOKEN] = token;
   if (ctx.req && cookie) {
-    axiosInstance.defaults.headers.Cookie = cookie;
+    Axios.defaults.headers.Cookie = cookie;
   }
 
   if (Component.getInitialProps) {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -28,6 +28,7 @@ type AppPropsWithLayout = AppProps & {
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
+      retry: false,
       staleTime: 3 * 60 * 1000,
       refetchOnMount: false,
       refetchOnReconnect: false,

--- a/src/pages/info/basic/index.tsx
+++ b/src/pages/info/basic/index.tsx
@@ -4,6 +4,7 @@ import { ReactElement, useCallback, ChangeEvent, useRef } from 'react';
 
 import ButtonFooter from '@atoms/ButtonFooter';
 import HeadMeta from '@atoms/HeadMeta';
+import Loading from '@atoms/Loading';
 import Span from '@atoms/Span';
 import TextInput from '@atoms/TextInput';
 import { ISR_WEEK } from '@constants/api';
@@ -17,6 +18,7 @@ import InfoBtnBox from '@organisms/InfoBtnBox';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';
 import { getStaticData } from 'src/api/staticData';
+import { useAuthTest } from 'src/hooks/api/login';
 import { useStaticData } from 'src/hooks/api/staticData';
 import { useInfoStore } from 'src/store/useInfoStore';
 import { filterHeight } from 'src/utils/filterValue';
@@ -46,6 +48,7 @@ export const getStaticProps = async () => {
 };
 
 export function BasicInfo() {
+  const { isSuccess } = useAuthTest();
   const state = useInfoStore((stat) => stat);
   const inputRef = useRef<HTMLInputElement>(null);
   const updateInfo = useInfoStore(useCallback((stat) => stat.infoUpdate, []));
@@ -85,6 +88,8 @@ export function BasicInfo() {
     router,
   ]);
 
+  if (!isSuccess)
+    return <Loading style={{ height: 'calc(var(--vh, 1vh) * 100)' }} />;
   return (
     <>
       <HeadMeta

--- a/src/pages/info/color/index.tsx
+++ b/src/pages/info/color/index.tsx
@@ -4,6 +4,7 @@ import { ReactElement, useCallback, useEffect } from 'react';
 
 import ButtonFooter from '@atoms/ButtonFooter';
 import HeadMeta from '@atoms/HeadMeta';
+import Loading from '@atoms/Loading';
 import { ISR_WEEK } from '@constants/api';
 import { colorBtnProps } from '@constants/colorInfo/constants';
 import { queryKey } from '@constants/react-query';
@@ -14,6 +15,7 @@ import InfoBtnBox from '@organisms/InfoBtnBox';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';
 import { getStaticData } from 'src/api/staticData';
+import { useAuthTest } from 'src/hooks/api/login';
 import { usePostPreference } from 'src/hooks/api/preference';
 import { useStaticData } from 'src/hooks/api/staticData';
 import { useInfoStore } from 'src/store/useInfoStore';
@@ -37,6 +39,7 @@ export const getStaticProps = async () => {
 };
 
 export function ColorInfo() {
+  const { isSuccess } = useAuthTest();
   const state = useInfoStore((stat) => stat);
   const handleClick = useInfoStore(useCallback((stat) => stat.infoUpdate, []));
   const { isLoading, data } = useStaticData<res.KindStaticData>('Color');
@@ -51,6 +54,8 @@ export function ColorInfo() {
 
   const handleSubmit = () => mutate(refinePreferenceData(state));
 
+  if (!isSuccess)
+    return <Loading style={{ height: 'calc(var(--vh, 1vh) * 100)' }} />;
   return (
     <>
       <HeadMeta

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -1,0 +1,20 @@
+/* eslint-disable consistent-return */
+import { NextRouter } from 'next/router';
+
+import { AxiosError } from 'axios';
+import { isInstanceOfAPIError } from 'src/api/core/error';
+import { toastError } from 'src/utils/toaster';
+
+export function errorHandler(err: AxiosError, router: NextRouter) {
+  if (isInstanceOfAPIError(err)) {
+    const { redirectUrl, notFound, status } = err;
+    if (notFound) {
+      return router.replace('/404');
+    }
+    if (status === 401 || status === 403)
+      toastError({ message: '다시 로그인해주세요.' });
+    if (redirectUrl) {
+      router.replace(redirectUrl);
+    }
+  }
+}


### PR DESCRIPTION
## 💡 이슈
resolve #139

## 🤩 개요
업로드 및 preference 화면 보이기 전에 인증 요청하기

## 🧑‍💻 작업 사항
### axios index 파일 리팩토링
#### interceptors 만들기
- axiosInstance에서 refresh된 토큰을 다이렉트로 넣다보니 반영이 잘 안돼서 interceptors를 만들게 되었습니다.
- request중에 가로채서 헤더에 accessToken을 넣어주었습니다.(SSR에서는 사용하면 안되므로 `typeof window !== 'undefined'`라는 조건을 분기했습니다.)
- 응답이 반환되었을 때, 403 token_expired 오류가 발생하면 refresh api를 요청하도록 구현했습니다.
- 마찬가지로 refresh api를 따로 분리했습니다.

### 업로드 및 preference 화면 보이기 전에 인증 요청하기
데이터 fetch가 많이 필요하므로 SSG를 사용했고 인증은 CSR에서 처리했습니다. 자세한 내용은 블로그에 정리했습니다.
[블로그 링크](https://kingyong9169.github.io/TIL/next/ssg_auth)

상품 수정 페이지에서도 마찬가지로 데이터 fetch가 많이 필요하여 SSG를 사용했는데 `getStaticPaths`가 필요합니다. 한가지 고민사항은 getStaticPaths를 통해 만들어진 SSG페이지는 모두 동일하지만 중복 생성된다는 점이 있고 그렇다고 SSR을 하기에는 매번 데이터 요청을 하는 것은 비효율적이라는 고민사항이 있습니다. 관련 내용도 블로그에 남기고자 합니다.

### react-query에서 공통적인 에러 처리하기
이전에 공통적인 에러를 처리하기 위해 useCoreQuery, useCoreMutation을 추상화하여 구현했습니다.
`errorHandler`를 만들어서 onError 옵션을 통해 공통적인 401, 403, 404 에러를 처리합니다.

이때 `onError`를 똑같이 사용하면 `override`되므로 구분하기 위해 `query hook`에서는 `onSettled`를 통해 에러 처리를 하고 공통적인 부분은 `onError`에서만 처리하고자 합니다. 자세한 내용은 블로그에 남기고자 합니다.

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.
