### PR TITLE
[feat] 상품 상태 변경 UI 추가 및 잔여 이슈 해결

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
-AI_API_URL="https://refashion.loca.lt/"
+AI_API_URL="https://116f-112-72-158-114.jp.ngrok.io/"
 API_URL="https://server.refashion.link/"
 CLIENT_URL="http://localhost:3001/"
 OAUTH_REDIRECT_URI="http://localhost:3001/oauth"

--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,4 @@
-AI_API_URL="https://refashion.loca.lt/"
+AI_API_URL="https://116f-112-72-158-114.jp.ngrok.io/"
 API_URL="https://server.refashion.link/"
 CLIENT_URL="https://refashion.link/"
 OAUTH_REDIRECT_URI="https://refashion.link/oauth"

--- a/src/api/category/index.ts
+++ b/src/api/category/index.ts
@@ -1,12 +1,11 @@
 import { Axios } from 'src/api/core';
 
-export const getCategory = async (): Promise<res.CategoryTree> => {
-  const response = await Axios.get('/api/category/v3');
-  return response;
-};
-
-export const getExcludeCategory = async (): Promise<res.CategoryTree> => {
-  const response = await Axios.get('/api/category/exclude');
+export const getSelectedCategory = async (
+  isExcluded: boolean,
+): Promise<res.CategoryTree> => {
+  const response = await Axios.get(
+    `/api/category/v3${isExcluded ? '/exclude' : ''}`,
+  );
   return response;
 };
 

--- a/src/api/product/index.ts
+++ b/src/api/product/index.ts
@@ -11,3 +11,8 @@ export const deleteProductDetail = async (id: string) => {
   const response = await Axios.delete(`/api/product/${id}`);
   return response;
 };
+
+export const updateProductStatus = async (id: string) => {
+  const response = await Axios.patch(`/api/product/status/${id}`);
+  return response;
+};

--- a/src/components/Product/organisms/ProductBasic/ProductBasicView.tsx
+++ b/src/components/Product/organisms/ProductBasic/ProductBasicView.tsx
@@ -1,0 +1,67 @@
+import { SaleStatusDataProp } from '#types/product';
+import { StyleProps } from '#types/props';
+import Span from '@atoms/Span';
+import { SaleStatusData } from '@constants/status';
+import SelectBox from '@molecules/SelectBox';
+import classnames from 'classnames';
+import { ProductBasicDataProp } from 'src/utils/product';
+import { replace } from 'src/utils/replace';
+
+import ProductCell from '../../atoms/ProductCell';
+import $ from './style.module.scss';
+
+type Props = {
+  isMe: boolean;
+  title: string;
+  classification: string;
+  datas: ProductBasicDataProp[];
+  saleStatus: SaleStatusDataProp;
+  handleStatusChange: (option: string) => void;
+} & StyleProps;
+
+export default function ProductBasicView(viewProps: Props) {
+  const { isMe, title, classification, datas } = viewProps;
+  const { handleStatusChange, saleStatus } = viewProps;
+
+  return (
+    <>
+      <header className={$['product-header']}>
+        <div className={$['product-title-box']}>
+          <h1 className={$['product-title']}>{title}</h1>
+          <span className={$['product-category']}>
+            {replace(classification, '/', ' > ')}
+          </span>
+        </div>
+        {isMe ? (
+          <SelectBox
+            onQueryChange={handleStatusChange}
+            options={SaleStatusData}
+            selected={saleStatus}
+            name="sale-status"
+            width="100px"
+            height="24px"
+            fontSize={14}
+            fontWeight={700}
+          />
+        ) : (
+          <Span
+            fontSize={14}
+            className={classnames($['product-status'], {
+              [$.soldout]: saleStatus === '판매완료',
+              [$.sale]: saleStatus === '판매중',
+              [$.reserved]: saleStatus === '예약중',
+            })}
+          >
+            {saleStatus}
+          </Span>
+        )}
+      </header>
+
+      <article>
+        {datas.map((data) => (
+          <ProductCell key={data.label} {...data} />
+        ))}
+      </article>
+    </>
+  );
+}

--- a/src/components/Product/organisms/ProductBasic/index.tsx
+++ b/src/components/Product/organisms/ProductBasic/index.tsx
@@ -1,14 +1,9 @@
-import { ProductBasicInfo } from '#types/product';
+import { ProductBasicInfo, SaleStatusDataProp } from '#types/product';
 import { StyleProps } from '#types/props';
-import Span from '@atoms/Span';
-import SelectBox from '@molecules/SelectBox';
-import classnames from 'classnames';
 import { useUpdateProductStatus } from 'src/hooks/api/product';
 import { productBasicUtil } from 'src/utils/product';
-import { replace } from 'src/utils/replace';
 
-import ProductCell from '../../atoms/ProductCell';
-import $ from './style.module.scss';
+import ProductBasicView from './ProductBasicView';
 
 type Props = {
   id: string;
@@ -22,46 +17,16 @@ export default function ProductBasic({ id, basic, isMe, isSoldOut }: Props) {
   const { mutate } = useUpdateProductStatus(id);
   const handleStatusChange = (option: string) => mutate(id); // TODO: 추후에 판매 상태 추가 후 option param 활용
   const datas = productBasicUtil(basic);
-  const saleStatus = isSoldOut ? '판매완료' : '판매중';
+  const saleStatus: SaleStatusDataProp = isSoldOut ? '판매완료' : '판매중';
 
-  return (
-    <>
-      <header className={$['product-header']}>
-        <div className={$['product-title-box']}>
-          <h1 className={$['product-title']}>{title}</h1>
-          <span className={$['product-category']}>
-            {replace(classification, '/', ' > ')}
-          </span>
-        </div>
-        {isMe ? (
-          <SelectBox
-            onQueryChange={handleStatusChange}
-            options={['판매중', '판매완료']}
-            selected={saleStatus}
-            name="sale-status"
-            width="100px"
-            height="24px"
-            fontSize={14}
-            fontWeight={700}
-          />
-        ) : (
-          <Span
-            fontSize={14}
-            className={classnames($['product-status'], {
-              [$.soldout]: saleStatus === '판매완료',
-              [$.sale]: saleStatus === '판매중',
-            })}
-          >
-            {saleStatus}
-          </Span>
-        )}
-      </header>
+  const props = {
+    isMe,
+    classification,
+    title,
+    datas,
+    saleStatus,
+    handleStatusChange,
+  };
 
-      <article>
-        {datas.map((data) => (
-          <ProductCell key={data.label} {...data} />
-        ))}
-      </article>
-    </>
-  );
+  return <ProductBasicView {...props} />;
 }

--- a/src/components/Product/organisms/ProductBasic/index.tsx
+++ b/src/components/Product/organisms/ProductBasic/index.tsx
@@ -1,5 +1,6 @@
 import { ProductBasicInfo } from '#types/product';
 import { StyleProps } from '#types/props';
+import SelectBox from '@molecules/SelectBox';
 import { productBasicUtil } from 'src/utils/product';
 import { replace } from 'src/utils/replace';
 
@@ -8,19 +9,32 @@ import $ from './style.module.scss';
 
 type Props = {
   basic: ProductBasicInfo;
+  isSoldOut: boolean;
 } & StyleProps;
 
-export default function ProductBasic({ basic }: Props) {
+export default function ProductBasic({ basic, isSoldOut }: Props) {
   const { title, classification } = basic;
   const datas = productBasicUtil(basic);
+  const saleStatus = isSoldOut ? '판매완료' : '판매중';
 
   return (
     <>
       <header className={$['product-header']}>
-        <h1 className={$['product-title']}>{title}</h1>
-        <span className={$['product-category']}>
-          {replace(classification, '/', ' > ')}
-        </span>
+        <div>
+          <h1 className={$['product-title']}>{title}</h1>
+          <span className={$['product-category']}>
+            {replace(classification, '/', ' > ')}
+          </span>
+        </div>
+        <SelectBox
+          options={['판매중', '판매완료']}
+          selected={saleStatus}
+          name="sale-status"
+          width="110px"
+          height="24px"
+          fontSize={14}
+          fontWeight={700}
+        />
       </header>
 
       <article>

--- a/src/components/Product/organisms/ProductBasic/index.tsx
+++ b/src/components/Product/organisms/ProductBasic/index.tsx
@@ -27,7 +27,7 @@ export default function ProductBasic({ id, basic, isMe, isSoldOut }: Props) {
   return (
     <>
       <header className={$['product-header']}>
-        <div>
+        <div className={$['product-title-box']}>
           <h1 className={$['product-title']}>{title}</h1>
           <span className={$['product-category']}>
             {replace(classification, '/', ' > ')}
@@ -39,7 +39,7 @@ export default function ProductBasic({ id, basic, isMe, isSoldOut }: Props) {
             options={['판매중', '판매완료']}
             selected={saleStatus}
             name="sale-status"
-            width="110px"
+            width="100px"
             height="24px"
             fontSize={14}
             fontWeight={700}
@@ -48,8 +48,8 @@ export default function ProductBasic({ id, basic, isMe, isSoldOut }: Props) {
           <Span
             fontSize={14}
             className={classnames($['product-status'], {
-              [$.soldout]: isSoldOut,
-              [$.sale]: !isSoldOut,
+              [$.soldout]: saleStatus === '판매완료',
+              [$.sale]: saleStatus === '판매중',
             })}
           >
             {saleStatus}

--- a/src/components/Product/organisms/ProductBasic/index.tsx
+++ b/src/components/Product/organisms/ProductBasic/index.tsx
@@ -1,6 +1,9 @@
 import { ProductBasicInfo } from '#types/product';
 import { StyleProps } from '#types/props';
+import Span from '@atoms/Span';
 import SelectBox from '@molecules/SelectBox';
+import classnames from 'classnames';
+import { useUpdateProductStatus } from 'src/hooks/api/product';
 import { productBasicUtil } from 'src/utils/product';
 import { replace } from 'src/utils/replace';
 
@@ -8,12 +11,16 @@ import ProductCell from '../../atoms/ProductCell';
 import $ from './style.module.scss';
 
 type Props = {
+  id: string;
   basic: ProductBasicInfo;
+  isMe: boolean;
   isSoldOut: boolean;
 } & StyleProps;
 
-export default function ProductBasic({ basic, isSoldOut }: Props) {
+export default function ProductBasic({ id, basic, isMe, isSoldOut }: Props) {
   const { title, classification } = basic;
+  const { mutate } = useUpdateProductStatus(id);
+  const handleStatusChange = (option: string) => mutate(id); // TODO: 추후에 판매 상태 추가 후 option param 활용
   const datas = productBasicUtil(basic);
   const saleStatus = isSoldOut ? '판매완료' : '판매중';
 
@@ -26,15 +33,28 @@ export default function ProductBasic({ basic, isSoldOut }: Props) {
             {replace(classification, '/', ' > ')}
           </span>
         </div>
-        <SelectBox
-          options={['판매중', '판매완료']}
-          selected={saleStatus}
-          name="sale-status"
-          width="110px"
-          height="24px"
-          fontSize={14}
-          fontWeight={700}
-        />
+        {isMe ? (
+          <SelectBox
+            onQueryChange={handleStatusChange}
+            options={['판매중', '판매완료']}
+            selected={saleStatus}
+            name="sale-status"
+            width="110px"
+            height="24px"
+            fontSize={14}
+            fontWeight={700}
+          />
+        ) : (
+          <Span
+            fontSize={14}
+            className={classnames($['product-status'], {
+              [$.soldout]: isSoldOut,
+              [$.sale]: !isSoldOut,
+            })}
+          >
+            {saleStatus}
+          </Span>
+        )}
       </header>
 
       <article>

--- a/src/components/Product/organisms/ProductBasic/style.module.scss
+++ b/src/components/Product/organisms/ProductBasic/style.module.scss
@@ -18,4 +18,27 @@
     }
     color: $gray-550;
   }
+  .product-status {
+    @include border(border, 5px, $gray-280);
+    width: 80px;
+    height: fit-content;
+    margin-left: 20px;
+    padding: 5px 10px;
+    text-align: center;
+  }
+  .sale {
+    border-color: $second;
+    background-color: rgba($second, 0.5);
+    color: $second-font-color;
+  }
+  .soldout {
+    border-color: $third;
+    background-color: rgba($third, 0.7);
+    color: $white;
+  }
+  .reserved {
+    border-color: $primary;
+    background-color: rgba($primary, 0.8);
+    color: $white;
+  }
 }

--- a/src/components/Product/organisms/ProductBasic/style.module.scss
+++ b/src/components/Product/organisms/ProductBasic/style.module.scss
@@ -1,5 +1,7 @@
 .product-header {
+  display: flex;
   margin-bottom: 19px;
+  justify-content: space-between;
   .product-title {
     font-weight: 700;
     @include typography(24);

--- a/src/components/Product/organisms/ProductBasic/style.module.scss
+++ b/src/components/Product/organisms/ProductBasic/style.module.scss
@@ -2,6 +2,10 @@
   display: flex;
   margin-bottom: 19px;
   justify-content: space-between;
+  .product-title-box {
+    margin-right: 20px;
+  }
+
   .product-title {
     font-weight: 700;
     @include typography(24);
@@ -10,6 +14,7 @@
     }
     color: $black-600;
   }
+
   .product-category {
     font-weight: 700;
     @include typography(14);
@@ -18,11 +23,11 @@
     }
     color: $gray-550;
   }
+
   .product-status {
     @include border(border, 5px, $gray-280);
     width: 80px;
     height: fit-content;
-    margin-left: 20px;
     padding: 5px 10px;
     text-align: center;
   }

--- a/src/components/shared/molecules/SelectBox/index.tsx
+++ b/src/components/shared/molecules/SelectBox/index.tsx
@@ -78,7 +78,7 @@ function SelectBox<T, U>(selectProps: Props<T, U>) {
         <Span
           fontSize={fontSize || 16}
           fontWeight={fontWeight || 400}
-          className={classnames({
+          className={classnames($.text, {
             [$['gender-text']]: isGender,
           })}
         >

--- a/src/components/shared/molecules/SelectBox/style.module.scss
+++ b/src/components/shared/molecules/SelectBox/style.module.scss
@@ -5,6 +5,7 @@
   display: flex;
   align-items: center;
   background-color: $white;
+  white-space: nowrap;
   @include border(border, 5px, $gray-280);
   &,
   button {
@@ -95,6 +96,10 @@
   path {
     stroke: $primary;
   }
+}
+
+.text {
+  margin-right: 5px;
 }
 
 .arrow {

--- a/src/components/shared/organisms/Footer/index.tsx
+++ b/src/components/shared/organisms/Footer/index.tsx
@@ -32,12 +32,12 @@ function Footer() {
       label: 'search',
       href: '/search',
     },
-    {
-      id: 3,
-      icon: Chat,
-      label: 'chat',
-      href: '/chat',
-    },
+    // {
+    //   id: 3,
+    //   icon: Chat,
+    //   label: 'chat',
+    //   href: '',
+    // },
     {
       id: 4,
       icon: MyPage,

--- a/src/components/shared/templates/UploadTemplate/index.tsx
+++ b/src/components/shared/templates/UploadTemplate/index.tsx
@@ -39,7 +39,7 @@ function UploadTemplate({ id, isUpdate, states }: Props) {
   const isMounted = useMounted();
   const { mutate } = useProductUpload();
   const { mutate: updateMutate } = useUpdateProduct(id);
-  const categoryData = useCategoryTree(false)?.data;
+  const categoryData = useCategoryTree(true)?.data;
   const { data: styles } = useStaticData<res.StaticData>('Style');
   const { data: bodyShapes } = useStaticData<res.StaticData>('BodyShape');
   const { data: pol } = useStaticData<res.StaticData>('PollutionCondition');

--- a/src/constants/status.ts
+++ b/src/constants/status.ts
@@ -4,3 +4,5 @@ export const statusData = [
   { name: '구매내역', code: 'purchased' },
   { name: '관심목록', code: 'likelist' },
 ];
+
+export const SaleStatusData = ['판매완료', '판매중'];

--- a/src/hooks/api/category/index.ts
+++ b/src/hooks/api/category/index.ts
@@ -1,12 +1,12 @@
 import { QUERY_DAYTIME, queryKey } from '@constants/react-query';
-import { getCategory, getExcludeCategory } from 'src/api/category';
+import { getSelectedCategory } from 'src/api/category';
 
 import { useCoreQuery } from '../core';
 
 export const useCategoryTree = (isExcluded: boolean) => {
   const response = useCoreQuery(
     queryKey.category(isExcluded),
-    () => (isExcluded ? getExcludeCategory() : getCategory()),
+    () => getSelectedCategory(isExcluded),
     {
       staleTime: QUERY_DAYTIME,
       suspense: true,

--- a/src/hooks/api/product/index.ts
+++ b/src/hooks/api/product/index.ts
@@ -2,7 +2,11 @@ import { useRouter } from 'next/router';
 
 import { queryKey } from '@constants/react-query';
 import { isAxiosError } from 'src/api/core/error';
-import { deleteProductDetail, getProductDetail } from 'src/api/product';
+import {
+  deleteProductDetail,
+  getProductDetail,
+  updateProductStatus,
+} from 'src/api/product';
 import { queryClient } from 'src/pages/_app';
 import { toastError, toastSuccess } from 'src/utils/toaster';
 
@@ -32,4 +36,20 @@ export function useDeleteProduct(id: string) {
     },
   });
   return response;
+}
+
+export function useUpdateProductStatus(id: string) {
+  return useCoreMutation(updateProductStatus, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(queryKey.productDetail(id));
+      queryClient.invalidateQueries(['productItemList']);
+      toastSuccess({ message: '상품상태를 변경했습니다.' });
+    },
+    onSettled: (_, err) => {
+      if (isAxiosError<res.error>(err) && !!err.response) {
+        const { message } = err.response.data;
+        toastError({ message });
+      }
+    },
+  });
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -30,7 +30,7 @@ export const queryClient = new QueryClient({
     queries: {
       retry: false,
       staleTime: 3 * 60 * 1000,
-      refetchOnMount: false,
+      refetchOnMount: true,
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,
     },

--- a/src/pages/shop/[id]/index.tsx
+++ b/src/pages/shop/[id]/index.tsx
@@ -67,7 +67,7 @@ function ShopDetail({ id }: { id: string }) {
           />
           <Profile profile={sellerInfo} needDetail />
           <section className={$['shop-detail-info']}>
-            <ProductBasic basic={basic} {...{ isSoldOut }} />
+            <ProductBasic basic={basic} {...{ id, isMe, isSoldOut }} />
             <ProductNotice sellerNotice={sellerNotice} />
             {measure && (
               <ProductSize size={measure} kind={basic.classification} />

--- a/src/pages/shop/[id]/index.tsx
+++ b/src/pages/shop/[id]/index.tsx
@@ -67,7 +67,7 @@ function ShopDetail({ id }: { id: string }) {
           />
           <Profile profile={sellerInfo} needDetail />
           <section className={$['shop-detail-info']}>
-            <ProductBasic basic={basic} />
+            <ProductBasic basic={basic} {...{ isSoldOut }} />
             <ProductNotice sellerNotice={sellerNotice} />
             {measure && (
               <ProductSize size={measure} kind={basic.classification} />

--- a/src/pages/shop/index.tsx
+++ b/src/pages/shop/index.tsx
@@ -9,7 +9,11 @@ import { seoData } from '@constants/seo';
 import Footer from '@organisms/Footer';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';
-import { getBreadcrumb, getCategory, getCategoryTree } from 'src/api/category';
+import {
+  getBreadcrumb,
+  getCategoryTree,
+  getSelectedCategory,
+} from 'src/api/category';
 import { withGetServerSideProps } from 'src/api/core/withGetServerSideProps';
 import { getInfiniteProducts, getProductItemList } from 'src/api/shop';
 import ProductItemList from 'src/components/Shop/Organisms/ProductItemList';
@@ -33,7 +37,9 @@ export const getServerSideProps = withGetServerSideProps(
 
     const queryClient = new QueryClient();
 
-    await queryClient.fetchQuery(queryKey.category(false), () => getCategory());
+    await queryClient.fetchQuery(queryKey.category(false), () =>
+      getSelectedCategory(false),
+    );
     await queryClient.fetchInfiniteQuery(
       queryKey.productItemList(queryStringObj),
       getInfiniteProducts({ queryStringObj, apiFunc: getProductItemList }),

--- a/src/pages/upload/[id]/index.tsx
+++ b/src/pages/upload/[id]/index.tsx
@@ -8,7 +8,7 @@ import { queryKey } from '@constants/react-query';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';
 import UploadTemplate from '@templates/UploadTemplate';
-import { getCategory } from 'src/api/category';
+import { getSelectedCategory } from 'src/api/category';
 import { getStaticData } from 'src/api/staticData';
 import { useUploadedProduct } from 'src/hooks/api/upload';
 import { useUploadUpdateStore } from 'src/store/upload/useUploadUpdateStore';
@@ -24,7 +24,9 @@ export const getStaticPaths = async () => {
 export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
   const id = params?.id as string;
   const queryClient = new QueryClient();
-  await queryClient.fetchQuery(queryKey.category(false), () => getCategory());
+  await queryClient.fetchQuery(queryKey.category(true), () =>
+    getSelectedCategory(true),
+  );
   await queryClient.fetchQuery(queryKey.staticData('Style'), () =>
     getStaticData('Style'),
   );

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -8,7 +8,7 @@ import { queryKey } from '@constants/react-query';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';
 import UploadTemplate from '@templates/UploadTemplate';
-import { getCategory } from 'src/api/category';
+import { getSelectedCategory } from 'src/api/category';
 import { getStaticData } from 'src/api/staticData';
 import { useAuthTest } from 'src/hooks/api/login';
 import { useUploadStore } from 'src/store/upload/useUploadStore';
@@ -17,7 +17,9 @@ import { judgeValid } from 'src/utils/upload.utils';
 
 export const getStaticProps = async () => {
   const queryClient = new QueryClient();
-  await queryClient.fetchQuery(queryKey.category(false), () => getCategory());
+  await queryClient.fetchQuery(queryKey.category(true), () =>
+    getSelectedCategory(true),
+  );
   await queryClient.fetchQuery(queryKey.staticData('Style'), () =>
     getStaticData('Style'),
   );

--- a/src/styles/_color.scss
+++ b/src/styles/_color.scss
@@ -3,6 +3,8 @@ $second: #b3ff85;
 $third: #ff9635;
 $forth: #ff61d7;
 
+$second-font-color: #19b450;
+
 $black-600: #000000;
 $black-500: #121212;
 $black-200: #4a4a4a;

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -36,3 +36,5 @@ export type ProductFooterInfo = {
   views: number;
   contact: string;
 };
+
+export type SaleStatusDataProp = '판매완료' | '판매중' | '예약중';

--- a/src/utils/product.ts
+++ b/src/utils/product.ts
@@ -7,7 +7,15 @@ import { Skirt, OnePiece, Pants, Top } from '@atoms/icon';
 
 import { replace } from './replace';
 
-export const productBasicUtil = (basic: ProductBasicInfo) => {
+export type ProductBasicDataProp = {
+  label: string;
+  desc: string;
+  isBottom?: boolean;
+};
+
+export const productBasicUtil = (
+  basic: ProductBasicInfo,
+): ProductBasicDataProp[] => {
   const { brand, productInfo, styleInfo } = basic;
 
   return [


### PR DESCRIPTION
## 💡 이슈
resolve #141 

## 🤩 개요
상품 상태 변경 UI 추가 및 잔여 이슈 해결

## 🧑‍💻 작업 사항
### 상품 상태 변경 UI 추가 및 api 연결
- 판매자는 판매 상태를 변경할 수 있고 구매자는 상품 상태를 볼 수 있도록 구현했습니다.
- 추후 확장성을 위해 view 컴포넌트에서는 "예약중" 상태에 대한 UI 또한 미리 구성했습니다. 이유는 로직 컴포넌트에서 변경사항이 발생해도 view컴포넌트에서는 발생하지 않도록 분리했습니다.

### getCategory api 리팩토링
- isExclude 선택 여부 결정으로 전체, 추천 제외 카테고리를 선택하도록 구성했습니다.

### 채팅 아이콘 제거

### invalidateQueries했을 시 동작안되는 이슈
- refetchOnMount: false로 놓아 이슈가 생겼습니다.
- invalidateQueries는 해당 key의 query들을 stale 상태로 놓는데
- refetchOnMount: true 옵션을 주면 stale 상태의 query들을 refetch합니다.

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.
