### PR TITLE
[feat] shop 페이지 FCP(로딩) 성능 개선하기

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -39,7 +39,7 @@ const nextConfig = {
   sassOptions: {
     includePaths: [path.join(__dirname, 'styles')],
     prependData:
-      '@import "src/styles/main.scss"; @import "src/styles/_mixin.scss"; @import "src/styles/_typography.scss"; @import "src/styles/_grid.scss";',
+      '@import "src/styles/main.scss"; @import "src/styles/_mixin.scss"; @import "src/styles/_typography.scss"; @import "src/styles/_grid.scss"; @import "src/styles/_loading.scss";',
   },
   env: {
     API_URL: process.env.API_URL,

--- a/src/components/Shop/Organisms/FilterModal/index.tsx
+++ b/src/components/Shop/Organisms/FilterModal/index.tsx
@@ -86,7 +86,5 @@ export default function FilterModal(filterProps: Props) {
     handlePriceChange,
   };
 
-  if (styles && colors && sizes && fits && lengths)
-    return <FilterModalView {...props} />;
-  return null;
+  return <FilterModalView {...props} />;
 }

--- a/src/components/Shop/Organisms/FilterModal/index.tsx
+++ b/src/components/Shop/Organisms/FilterModal/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useRef } from 'react';
 
 import { FilterType } from '#types/storeType/filter';
 import { useQueryObjRouter } from 'src/hooks';
+import { useStaticData } from 'src/hooks/api/staticData';
 import { useFilterStore } from 'src/store/useFilterStore';
 import { filterMaxPrice, validatePriceRange } from 'src/utils';
 
@@ -17,6 +18,13 @@ type Props = {
 
 export default function FilterModal(filterProps: Props) {
   const { isOpen, onClose, mainCategory } = filterProps;
+  const { data: styles } = useStaticData<res.StaticData>('Style');
+  const { data: colors } = useStaticData<res.KindStaticData>('Color');
+  const { data: sizes } = useStaticData<res.KindStaticData>('Size');
+  const { data: lengths } = useStaticData<res.KindStaticData>('Length');
+  const { data: fits } = useStaticData<res.KindStaticData>('Fit');
+  const datas = { styles, colors, sizes, lengths, fits };
+
   const router = useQueryObjRouter();
   const clearState = useFilterStore(useCallback((stat) => stat.clear, []));
 
@@ -61,7 +69,7 @@ export default function FilterModal(filterProps: Props) {
   );
 
   const priceProp = priceProps(states.price);
-  const filterDatas = filterData(mainCategory);
+  const filterDatas = filterData(mainCategory, datas);
 
   const props = {
     isOpen,
@@ -78,5 +86,7 @@ export default function FilterModal(filterProps: Props) {
     handlePriceChange,
   };
 
-  return <FilterModalView {...props} />;
+  if (styles && colors && sizes && fits && lengths)
+    return <FilterModalView {...props} />;
+  return null;
 }

--- a/src/components/Shop/Organisms/FilterModal/utils.ts
+++ b/src/components/Shop/Organisms/FilterModal/utils.ts
@@ -5,15 +5,20 @@ import {
   FilterType,
   FilterState,
 } from '#types/storeType/filter';
-import { bottomSizes } from '@constants/basic';
-import { colorsData, topSizes } from '@constants/index';
-import { fitsData, lengthsData, stylesData } from '@constants/style';
 
 export type btnBox = btnTemplateBox<
   keyof Omit<FilterState, 'price'>,
   keyof ClothesCategory
 > & {
   datas: (string | DefaultData)[];
+};
+
+type FilterDatas = {
+  styles?: res.StaticData;
+  colors?: res.KindStaticData;
+  sizes?: res.KindStaticData;
+  fits?: res.KindStaticData;
+  lengths?: res.KindStaticData;
 };
 
 type FilterElement = {
@@ -26,50 +31,55 @@ type FilterElement = {
   clothesSize: string;
 };
 
-const commonProps: btnBox[] = [
+const commonProps = (styles: FilterDatas['styles']): btnBox[] => [
   {
     label: '스타일',
     type: 'style',
-    datas: stylesData,
+    datas: styles?.data || [],
     noCheckColor: true,
   },
 ];
 
-export const filterData = (category: FilterType): btnBox[] => {
+export const filterData = (
+  category: FilterType,
+  datas: FilterDatas,
+): btnBox[] => {
+  const { styles, colors, sizes, fits, lengths } = datas;
+  const commonData = commonProps(styles);
   const categoryCondition = category === 'top' ? 'top' : 'bottom';
   switch (category) {
     case 'all':
-      return [...commonProps];
+      return [...commonData];
     case 'top':
     case 'bottom':
       return [
-        ...commonProps,
+        ...commonData,
         {
           label: '컬러',
           type: 'color',
           subType: categoryCondition,
           isColor: true,
-          datas: colorsData,
+          datas: colors?.data.top || [],
         },
         {
           label: '핏',
           type: 'fit',
           subType: categoryCondition,
-          datas: fitsData[categoryCondition],
+          datas: fits?.data[categoryCondition] || [],
           noCheckColor: true,
         },
         {
           label: '기장',
           type: 'length',
           subType: categoryCondition,
-          datas: lengthsData[categoryCondition],
+          datas: lengths?.data[categoryCondition] || [],
           noCheckColor: true,
         },
         {
           label: '사이즈',
           type: 'clothesSize',
           subType: categoryCondition,
-          datas: category === 'top' ? topSizes : bottomSizes,
+          datas: sizes?.data[category === 'top' ? 'top' : 'bottom'] || [],
           noCheckColor: true,
         },
       ];

--- a/src/components/Shop/molecules/HeaderTool/index.tsx
+++ b/src/components/Shop/molecules/HeaderTool/index.tsx
@@ -5,9 +5,12 @@ import { useState } from 'react';
 import { FilterType } from '#types/storeType/filter';
 import BackBtn from '@atoms/BackBtn';
 import Button from '@atoms/Button';
+import ErrorFallback from '@atoms/ErrorFallback';
 import { Filter, Search } from '@atoms/icon';
 import Span from '@atoms/Span';
 import SelectBox from '@molecules/SelectBox';
+import AsyncBoundary from '@templates/AsyncBoundary';
+import FilterSkeleton from '@templates/Skeleton/Filter';
 import FilterModal from 'src/components/Shop/Organisms/FilterModal';
 
 import $ from './style.module.scss';
@@ -68,19 +71,24 @@ function HeaderTool(headerProps: Props) {
           </button>
         </Link>
 
-        <Button
-          iconBtn
-          label="상품 필터 버튼"
-          className={$.btn}
-          onClick={openFilterModal}
+        <AsyncBoundary
+          suspenseFallback={<FilterSkeleton />}
+          errorFallback={ErrorFallback}
         >
-          <Filter />
-        </Button>
-        <FilterModal
-          {...{ mainCategory }}
-          isOpen={filterOpen}
-          onClose={closeFilterModal}
-        />
+          <Button
+            iconBtn
+            label="상품 필터 버튼"
+            className={$.btn}
+            onClick={openFilterModal}
+          >
+            <Filter fill="#C9B6FF" stroke="#936DFF" />
+          </Button>
+          <FilterModal
+            {...{ mainCategory }}
+            isOpen={filterOpen}
+            onClose={closeFilterModal}
+          />
+        </AsyncBoundary>
       </section>
     </section>
   );

--- a/src/components/shared/atoms/icon/Filter.tsx
+++ b/src/components/shared/atoms/icon/Filter.tsx
@@ -1,6 +1,6 @@
-import type { StyleProps } from '#types/props';
+import type { IconProps } from '#types/props';
 
-function Filter({ className, style }: StyleProps) {
+function Filter({ className, style, stroke, fill }: IconProps) {
   return (
     <svg
       {...{ className, style }}
@@ -10,18 +10,18 @@ function Filter({ className, style }: StyleProps) {
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <line y1="2.5" x2="19" y2="2.5" stroke="#936DFF" strokeWidth="3" />
+      <line y1="2.5" x2="19" y2="2.5" stroke={stroke} strokeWidth="3" />
       <line
         opacity="0.5"
         y1="9.5"
         x2="19"
         y2="9.5"
-        stroke="#936DFF"
+        stroke={stroke}
         strokeWidth="3"
       />
-      <line y1="16.5" x2="19" y2="16.5" stroke="#936DFF" strokeWidth="3" />
-      <circle cx="13.5" cy="2.5" r="2.5" fill="#C9B6FF" />
-      <circle cx="5.5" cy="16.5" r="2.5" fill="#C9B6FF" />
+      <line y1="16.5" x2="19" y2="16.5" stroke={stroke} strokeWidth="3" />
+      <circle cx="13.5" cy="2.5" r="2.5" stroke="none" fill={fill} />
+      <circle cx="5.5" cy="16.5" r="2.5" stroke="none" fill={fill} />
     </svg>
   );
 }

--- a/src/components/shared/templates/Skeleton/Filter/index.tsx
+++ b/src/components/shared/templates/Skeleton/Filter/index.tsx
@@ -1,0 +1,13 @@
+import { Filter } from '@atoms/icon';
+
+import $ from './style.module.scss';
+
+function FilterSkeleton() {
+  return (
+    <div className={$['skeleton-filter']}>
+      <Filter className={$.filter} />
+    </div>
+  );
+}
+
+export default FilterSkeleton;

--- a/src/components/shared/templates/Skeleton/Filter/style.module.scss
+++ b/src/components/shared/templates/Skeleton/Filter/style.module.scss
@@ -1,0 +1,6 @@
+.skeleton-filter {
+  display: flex;
+  .filter {
+    @include iconLoading();
+  }
+}

--- a/src/pages/shop/index.tsx
+++ b/src/pages/shop/index.tsx
@@ -1,10 +1,8 @@
-import { GetServerSidePropsContext } from 'next';
-
 import { ReactElement } from 'react';
 
 import HeadMeta from '@atoms/HeadMeta';
 import { queries, queryData } from '@constants/queryString';
-import { queryKey, QUERY_DAYTIME } from '@constants/react-query';
+import { queryKey } from '@constants/react-query';
 import { seoData } from '@constants/seo';
 import Footer from '@organisms/Footer';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
@@ -14,51 +12,26 @@ import {
   getCategoryTree,
   getSelectedCategory,
 } from 'src/api/category';
-import { withGetServerSideProps } from 'src/api/core/withGetServerSideProps';
-import { getInfiniteProducts, getProductItemList } from 'src/api/shop';
 import ProductItemList from 'src/components/Shop/Organisms/ProductItemList';
 import ShopHeader from 'src/components/Shop/Organisms/ShopHeader';
 import { categoryPropArr } from 'src/components/Upload/organisms/Dialog/utils';
 import { useMultipleSearch } from 'src/hooks';
 import { useCategoryTree } from 'src/hooks/api/category';
-import { getQueryStringObj, getQueriesArr } from 'src/utils';
 import { judgeCategoryId } from 'src/utils/shop.utils';
 
-export const getServerSideProps = withGetServerSideProps(
-  async ({ query }: GetServerSidePropsContext) => {
-    const { category, hideSold, order, style } = query;
-    const { priceGoe, priceLoe, color, fit, length, clothesSize } = query;
-    const arr1 = [category, hideSold, order, style]; // TODO: obj로 변경
-    const arr2 = [priceGoe, priceLoe, color, fit, length, clothesSize];
-    const queryArr = [...arr1, ...arr2];
+export const getStaticProps = async () => {
+  const queryClient = new QueryClient();
 
-    const queryObj = getQueriesArr(queryData, queryArr);
-    const queryStringObj = getQueryStringObj(queryObj);
+  await queryClient.fetchQuery(queryKey.category(false), () =>
+    getSelectedCategory(false),
+  );
 
-    const queryClient = new QueryClient();
-
-    await queryClient.fetchQuery(queryKey.category(false), () =>
-      getSelectedCategory(false),
-    );
-    await queryClient.fetchInfiniteQuery(
-      queryKey.productItemList(queryStringObj),
-      getInfiniteProducts({ queryStringObj, apiFunc: getProductItemList }),
-      {
-        getNextPageParam: ({ pagination: { isEndOfPage, pageNumber } }) => {
-          return isEndOfPage ? undefined : pageNumber + 1;
-        },
-        cacheTime: QUERY_DAYTIME,
-        staleTime: QUERY_DAYTIME,
-      },
-    );
-
-    return {
-      props: {
-        dehydratedState: JSON.parse(JSON.stringify(dehydrate(queryClient))),
-      },
-    };
-  },
-);
+  return {
+    props: {
+      dehydratedState: JSON.parse(JSON.stringify(dehydrate(queryClient))),
+    },
+  };
+};
 
 function Shop() {
   const data = useCategoryTree(false)?.data;

--- a/src/pages/shop/index.tsx
+++ b/src/pages/shop/index.tsx
@@ -12,6 +12,7 @@ import {
   getCategoryTree,
   getSelectedCategory,
 } from 'src/api/category';
+import { getStaticData } from 'src/api/staticData';
 import ProductItemList from 'src/components/Shop/Organisms/ProductItemList';
 import ShopHeader from 'src/components/Shop/Organisms/ShopHeader';
 import { categoryPropArr } from 'src/components/Upload/organisms/Dialog/utils';
@@ -24,6 +25,21 @@ export const getStaticProps = async () => {
 
   await queryClient.fetchQuery(queryKey.category(false), () =>
     getSelectedCategory(false),
+  );
+  await queryClient.fetchQuery(queryKey.staticData('Style'), () =>
+    getStaticData('Style'),
+  );
+  await queryClient.fetchQuery(queryKey.staticData('Color'), () =>
+    getStaticData('Color'),
+  );
+  await queryClient.fetchQuery(queryKey.staticData('Size'), () =>
+    getStaticData('Size'),
+  );
+  await queryClient.fetchQuery(queryKey.staticData('Length'), () =>
+    getStaticData('Length'),
+  );
+  await queryClient.fetchQuery(queryKey.staticData('Fit'), () =>
+    getStaticData('Fit'),
   );
 
   return {

--- a/src/styles/_loading.scss
+++ b/src/styles/_loading.scss
@@ -1,0 +1,90 @@
+@mixin loading() {
+  @-webkit-keyframes loading {
+    0% {
+      background-color: $skeleton-start;
+    }
+    50% {
+      background-color: $skeleton-mid;
+    }
+    100% {
+      background-color: $skeleton-start;
+    }
+  }
+
+  @-moz-keyframes loading {
+    0% {
+      background-color: $skeleton-start;
+    }
+    50% {
+      background-color: $skeleton-mid;
+    }
+    100% {
+      background-color: $skeleton-start;
+    }
+  }
+
+  @keyframes loading {
+    0% {
+      background-color: $skeleton-start;
+    }
+    50% {
+      background-color: $skeleton-mid;
+    }
+    100% {
+      background-color: $skeleton-start;
+    }
+  }
+  -webkit-animation: loading 1.8s infinite ease-in-out;
+  -moz-animation: loading 1.8s infinite ease-in-out;
+  animation: loading 1.8s infinite ease-in-out;
+}
+
+@mixin iconLoading() {
+  @-webkit-keyframes loading {
+    0% {
+      stroke: $gray-550;
+      fill: $gray-280;
+    }
+    50% {
+      stroke: $skeleton-mid;
+      fill: $skeleton-start;
+    }
+    100% {
+      stroke: $gray-550;
+      fill: $gray-280;
+    }
+  }
+
+  @-moz-keyframes loading {
+    0% {
+      stroke: $gray-550;
+      fill: $gray-280;
+    }
+    50% {
+      stroke: $skeleton-mid;
+      fill: $skeleton-start;
+    }
+    100% {
+      stroke: $gray-550;
+      fill: $gray-280;
+    }
+  }
+
+  @keyframes loading {
+    0% {
+      stroke: $gray-550;
+      fill: $gray-280;
+    }
+    50% {
+      stroke: $skeleton-mid;
+      fill: $skeleton-start;
+    }
+    100% {
+      stroke: $gray-550;
+      fill: $gray-280;
+    }
+  }
+  -webkit-animation: loading 1.8s infinite ease-in-out;
+  -moz-animation: loading 1.8s infinite ease-in-out;
+  animation: loading 1.8s infinite ease-in-out;
+}

--- a/src/styles/_mixin.scss
+++ b/src/styles/_mixin.scss
@@ -144,47 +144,6 @@
   text-overflow: ellipsis;
 }
 
-@mixin loading() {
-  @-webkit-keyframes loading {
-    0% {
-      background-color: $skeleton-start;
-    }
-    50% {
-      background-color: $skeleton-mid;
-    }
-    100% {
-      background-color: $skeleton-start;
-    }
-  }
-
-  @-moz-keyframes loading {
-    0% {
-      background-color: $skeleton-start;
-    }
-    50% {
-      background-color: $skeleton-mid;
-    }
-    100% {
-      background-color: $skeleton-start;
-    }
-  }
-
-  @keyframes loading {
-    0% {
-      background-color: $skeleton-start;
-    }
-    50% {
-      background-color: $skeleton-mid;
-    }
-    100% {
-      background-color: $skeleton-start;
-    }
-  }
-  -webkit-animation: loading 1.8s infinite ease-in-out;
-  -moz-animation: loading 1.8s infinite ease-in-out;
-  animation: loading 1.8s infinite ease-in-out;
-}
-
 @mixin FadeDown() {
   @keyframes FadeDown {
     from {


### PR DESCRIPTION
## 💡 이슈
resolve #147 

## 🤩 개요
shop 페이지 로딩 성능 개선하기

## 🧑‍💻 작업 사항

- [x] SSR을 SSG + CSR로 변경
- [x] 성능 차이 측정하기
- [x] Filter에 SSG 및 스켈레톤 적용하기

## 📖 참고 사항
### 성능차이
<img width="1356" alt="스크린샷 2022-11-08 오후 10 28 42" src="https://user-images.githubusercontent.com/62797441/200635018-d20408b5-a242-4807-8811-2746ee22e686.png">
보다시피 2.31초라는 FCP가 발생했다.. 유저가 많지 않은 상황임에도 이런 상황이 발생하는 것은 vercel 무료버전에서 serverless function지원은 좋지 못하기 때문이다. 따라서 이를 개선해야 한다는 것을 인지했고 SSG + CSR로 해결했다. 더 자세한 내용은 블로그를 통해 기록하고자 한다.

https://user-images.githubusercontent.com/62797441/200634179-73bf1955-c8d7-4063-b48b-65cc9cba2575.mov
- 로컬에서 작업할 때 SSR을 사용할 때는 0.389초라는 딜레이가 생겼다.

https://user-images.githubusercontent.com/62797441/200634481-b336f573-14fa-475d-b9c0-de4fce1a98a6.mov
- 반면 SSG + CSR의 경우 api call에 대한 시간 딜레이만 생기므로 SSR에 비해 성능적으로 좋은 모습을 보인다. 0.193초의 성능을 보인다. 이것마저도 로컬에서 실험했기에 SSG가 반영되지 않은 시간으로 실제 prod 환경에서는 더 좋은 모습을 보였습니다.

![스크린샷 2022-10-05 오전 7 15 03](https://user-images.githubusercontent.com/62797441/230663744-e067db31-91b0-4514-b2a6-7dc03b463eef.png)

![성능 최적화 전](https://user-images.githubusercontent.com/62797441/230656733-114ed7ba-5873-4e5c-8b80-7f58362d1fbf.png)

![스크린샷 2022-11-13 오후 11 28 54](https://user-images.githubusercontent.com/62797441/201527008-0e391ee3-6ffb-432a-b10d-d76f4e44be4c.png)



### Filter에 SSG 및 스켈레톤 적용하기
Filter에는 5개의 api를 호출해야 하고 SSR혹은 CSR을 사용하면 불필요한 api call이 발생한다. 따라서 SSG를 사용했다.
그리고 SSG를 사용하지 않을 때의 ux를 대비하기 위해 AsyncBoundary을 이용하여 스켈레톤을 적용했고 실제 filter의 style을 적용하여 CLS 수치를 없애도록 노력했다.

https://user-images.githubusercontent.com/62797441/200635966-15db0598-d080-4831-b0a1-ca4ac0055a78.mov


