### PR TITLE
[feat] 상품 수정 페이지 FCP 성능 향상

### DIFF
--- a/src/api/login/index.ts
+++ b/src/api/login/index.ts
@@ -32,6 +32,6 @@ export const logoutUtil = () => {
 };
 
 export const authTest = async () => {
-  const response = await Axios.get('/auth-testing');
+  const response = await Axios.get('/auth-verification');
   return response;
 };

--- a/src/components/Product/organisms/ProductImgSlide/index.tsx
+++ b/src/components/Product/organisms/ProductImgSlide/index.tsx
@@ -26,7 +26,7 @@ function ProductImgSlide(slideProps: Props) {
     [],
   );
   const updateProduct = useCallback(() => {
-    router.push(`/upload/${id}`);
+    router.push(`/upload/update?id=${id}`);
   }, [id, router]);
   const report = useCallback(
     () => toastError({ message: '준비중입니다.' }),

--- a/src/constants/api/index.ts
+++ b/src/constants/api/index.ts
@@ -10,7 +10,9 @@ export const ACCESSTOKEN = 'x-access-token';
 
 export const ACCESSTOKEN_EXPIRED = 'TOKEN_EXPIRED';
 export const USER_NOT_EXISTED = 'USER_NOT_EXISTED';
+
 export const PRODUCT_NOT_FOUND_MSG = '해당 상품이 존재하지 않습니다';
+export const INVALID_TYPE_VALUE_MSG = ' Invalid Type Value';
 
 export const TOKEN_REFRESH = 'api/auth/reissue';
 

--- a/src/hooks/api/upload/index.ts
+++ b/src/hooks/api/upload/index.ts
@@ -2,6 +2,7 @@ import router from 'next/router';
 
 import { useCallback } from 'react';
 
+import { INVALID_TYPE_VALUE_MSG } from '@constants/api';
 import { queryKey } from '@constants/react-query';
 import { isAxiosError } from 'src/api/core/error';
 import {
@@ -79,6 +80,12 @@ export const useUploadedProduct = (id: string) => {
       enabled: !!id,
       onSettled: (_, err) => {
         if (isAxiosError<res.error>(err) && err.response) {
+          const { message } = err.response.data;
+          if (message === INVALID_TYPE_VALUE_MSG) {
+            router.replace('/404');
+            toastError({ message: '잘못된 상품 id값입니다.' });
+            return;
+          }
           toastError({ message: err.response.data.message });
         }
       },

--- a/src/hooks/api/upload/index.ts
+++ b/src/hooks/api/upload/index.ts
@@ -76,6 +76,7 @@ export const useUploadedProduct = (id: string) => {
     queryKey.uploadedProduct(id),
     () => getUploadedProduct(id),
     {
+      enabled: !!id,
       onSettled: (_, err) => {
         if (isAxiosError<res.error>(err) && err.response) {
           toastError({ message: err.response.data.message });

--- a/src/pages/upload/update/index.tsx
+++ b/src/pages/upload/update/index.tsx
@@ -12,6 +12,8 @@ import { getSelectedCategory } from 'src/api/category';
 import { getStaticData } from 'src/api/staticData';
 import { useUploadedProduct } from 'src/hooks/api/upload';
 import { useUploadUpdateStore } from 'src/store/upload/useUploadUpdateStore';
+import { getPropFromQuery } from 'src/utils';
+import { toastError } from 'src/utils/toaster';
 import { uploadedDataToState } from 'src/utils/upload.utils';
 
 export const getStaticProps = async () => {
@@ -50,8 +52,9 @@ export const getStaticProps = async () => {
 };
 
 function UploadUpdate() {
-  const router = useRouter();
-  const id = router.query.id as string;
+  const { asPath, replace } = useRouter();
+  const searchParams = asPath.split('?')[1];
+  const id = getPropFromQuery(searchParams, 'id') || '';
   const { data, isSuccess } = useUploadedProduct(id);
   const states = useUploadUpdateStore((state) => state);
   const { initState } = states;
@@ -61,6 +64,13 @@ function UploadUpdate() {
   useEffect(() => {
     if (data && state) initUploads(state);
   }, [data]);
+
+  useEffect(() => {
+    if (!id) {
+      replace('/404');
+      toastError({ message: '잘못된 상품 id값입니다.' });
+    }
+  }, [id]);
 
   if (isSuccess) return <UploadTemplate {...{ id, states, isUpdate: true }} />;
   return <Loading style={{ height: 'calc(var(--vh, 1vh) * 100)' }} />;

--- a/src/pages/upload/update/index.tsx
+++ b/src/pages/upload/update/index.tsx
@@ -1,4 +1,4 @@
-import { GetStaticPropsContext } from 'next';
+import { useRouter } from 'next/router';
 
 import { ReactElement, useCallback, useEffect } from 'react';
 
@@ -14,15 +14,7 @@ import { useUploadedProduct } from 'src/hooks/api/upload';
 import { useUploadUpdateStore } from 'src/store/upload/useUploadUpdateStore';
 import { uploadedDataToState } from 'src/utils/upload.utils';
 
-export const getStaticPaths = async () => {
-  const paths = Array.from({ length: 10 }, (_, i) => ({
-    params: { id: `${i + 1}` },
-  }));
-  return { paths, fallback: true };
-};
-
-export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
-  const id = params?.id as string;
+export const getStaticProps = async () => {
   const queryClient = new QueryClient();
   await queryClient.fetchQuery(queryKey.category(true), () =>
     getSelectedCategory(true),
@@ -51,14 +43,15 @@ export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
 
   return {
     props: {
-      id,
       dehydratedState: dehydrate(queryClient),
     },
     revalidate: ISR_WEEK,
   };
 };
 
-function UploadUpdate({ id }: { id: string }) {
+function UploadUpdate() {
+  const router = useRouter();
+  const id = router.query.id as string;
   const { data, isSuccess } = useUploadedProduct(id);
   const states = useUploadUpdateStore((state) => state);
   const { initState } = states;


### PR DESCRIPTION
## 💡 이슈
resolve #154 

## 🤩 개요
상품 수정 페이지 FCP 성능 향상

## 🧑‍💻 작업 사항

- [x] 상품 수정 페이지 FCP 성능 향상
- [x] 예외 처리

## 📖 참고 사항

### 실제 vercel에서의 운영 환경 및 현 상황의 문제점
https://user-images.githubusercontent.com/62797441/200987771-a9b04c40-7472-487c-a750-95eead610a1a.mov

`getStaticPaths`를 사용했기에 미리 만들어진 path의 경우에는 `pre-rendering`되고 캐싱되어 정말 빠릅니다. 하지만 그렇지 않은 path의 경우에는 `fallback:true` 옵션을 통해 다시 파일을 만들어야 하기 때문에 처음에 오류가 발생했다가 `6.57`초가 되어서야 다시 만들어져서 응답이 옵니다. 이렇게 되면 **FCP**에 악영향을 미칩니다.

뿐만 아니라 `서버 자원 소모과 불필요한 파일이 생성되는 문제점`이 있었습니다. `getStaticPaths`를 사용하기 위해 백엔드에 api를 요청함은 물론 이렇게 페이지를 `pre-render`했다고 하더라도 모든 파일(`upload/1, upload/2..`)이 전부 같은 내용으로 채워져 있어(`SSG + CSR`방식으로 인해 실시간으로 서버로부터 받아야 하는 데이터는 `CSR`로 처리) `pre-render`하는 의미가 없어집니다.

### 해결
`query string`을 사용하여 해결했습니다. SSG파일 하나와 id값에 따라 페이지에 필요한 데이터를 `CSR`을 통해 요청하도록 구현했습니다. 이로 인해 현 상황의 문제점을 모두 해결할 수 있습니다.

#### 성능 향상
`68ms`로 정말 많은 시간 단축을 이룰 수 있었습니다. 비록 로컬이지만 `vercel`에서도 비슷한 속도로 동작할 것으로 예상됩니다.

https://user-images.githubusercontent.com/62797441/200989033-1492f322-83bf-45f6-a4a9-77066c1da762.mov

#### 다른 판매자의 상품 접근
`403` 에러 핸들링을 통해 로그인 페이지에 접근합니다.

https://user-images.githubusercontent.com/62797441/200989130-909ceda7-e564-4ca1-970d-17b1b212bb08.mov

#### 없는 상품 접근
없는 상품이므로 `404` 페이지로 `redirect`합니다.

https://user-images.githubusercontent.com/62797441/200989178-4ae61d56-d350-408d-975e-4a4254b12f85.mov

#### id값이 올바른 값이 아닌 경우
`id`값이 맞지 않는 경우는 서버에서 판단하는 것이 맞다고 생각하여 mutation hook에서 처리했습니다. `id`값이 존재하지 않는 경우에는 요청조차 하지 않는 것이 맞다고 생각했습니다. 따라서 `enabled`옵션을 사용하고 클라이언트에서 `404 redirect` 처리를 했습니다.

이렇게 성능 향상과 예외 처리를 통해 현 상황의 문제점을 모두 해결했습니다.