### PR TITLE
[Feat] 작은 UI 이슈 해결

### DIFF
--- a/src/components/Main/organisms/TodayRecommend/style.module.scss
+++ b/src/components/Main/organisms/TodayRecommend/style.module.scss
@@ -4,7 +4,7 @@
   left: 50%;
   transform: translateX(-50%);
   max-width: 500px;
-  min-height: 361px;
+  min-height: 300px;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/components/Main/organisms/TodayRecommend/style.module.scss
+++ b/src/components/Main/organisms/TodayRecommend/style.module.scss
@@ -4,14 +4,17 @@
   left: 50%;
   transform: translateX(-50%);
   max-width: 500px;
+  min-height: 361px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
   margin: 71px 0 15px;
   padding-top: 20px;
   border-radius: 19px;
   background-color: rgba($second, 0.25);
+  @include mobile() {
+    border-radius: 0;
+  }
 }
 
 .circle {

--- a/src/components/Product/atoms/ProductCell/style.module.scss
+++ b/src/components/Product/atoms/ProductCell/style.module.scss
@@ -19,6 +19,7 @@
     font-weight: 400;
     text-align: right;
     word-break: keep-all;
+    word-wrap: break-word;
   }
 }
 

--- a/src/components/Shop/Organisms/ShopHeader/index.tsx
+++ b/src/components/Shop/Organisms/ShopHeader/index.tsx
@@ -17,6 +17,7 @@ type Props = {
   genderSelectMenu: res.CategoryTreeChildren[];
   selectData: res.CategoryTreeChildren[];
   breadCrumb: string;
+  isRecommend: boolean;
 };
 
 function ShopHeader(headerProps: Props) {
@@ -26,7 +27,7 @@ function ShopHeader(headerProps: Props) {
   const queryHideSold = useQueryRouter('hideSold', 'REPLACE');
   const { categoryQuery, orderQuery, hideSoldQuery } = headerProps;
   const { genderSelectMenu, selectData } = headerProps;
-  const { genderQuery, breadCrumb } = headerProps;
+  const { genderQuery, breadCrumb, isRecommend } = headerProps;
   const isSelectedSub = categoryQuery.length === 7;
   const selectedMenu = categoryQuery;
   const mainCategory = judgeMainCategory(breadCrumb);
@@ -37,7 +38,7 @@ function ShopHeader(headerProps: Props) {
     <header className={$.header}>
       <HeaderTool
         {...{ onClick: queryCategory, breadCrumb }}
-        {...{ isSelectedSub, mainCategory }}
+        {...{ isSelectedSub, mainCategory, isRecommend }}
         data={genderSelectMenu}
         selectedMenu={genderQuery}
       />

--- a/src/components/Shop/molecules/CategoryBox/style.module.scss
+++ b/src/components/Shop/molecules/CategoryBox/style.module.scss
@@ -4,6 +4,7 @@
   justify-content: center;
   padding: 0 12px;
   word-break: keep-all;
+  word-wrap: break-word;
 
   .category-list {
     overflow: hidden;
@@ -22,6 +23,7 @@
 .sub-box {
   background-color: $category-box;
   word-break: keep-all;
+  word-wrap: break-word;
 }
 
 .arrow {

--- a/src/components/Shop/molecules/HeaderTool/index.tsx
+++ b/src/components/Shop/molecules/HeaderTool/index.tsx
@@ -51,14 +51,16 @@ function HeaderTool(headerProps: Props) {
         {!isSelectedSub && (
           <SelectBox
             {...{ onQueryChange: onClick }}
-            options={data}
-            selected={selectedMenu}
-            name="category"
-            width="100px"
-            height="33px"
-            fontWeight={700}
             isGender
             hasId
+            isSameCodeName
+            options={data}
+            selected={selectedMenu}
+            name="gender"
+            width="fit-content"
+            height="33px"
+            fontSize={13}
+            fontWeight={700}
           />
         )}
 

--- a/src/components/Shop/molecules/HeaderTool/index.tsx
+++ b/src/components/Shop/molecules/HeaderTool/index.tsx
@@ -21,11 +21,12 @@ type Props = {
   isSelectedSub: boolean;
   breadCrumb: string;
   mainCategory: FilterType;
+  isRecommend: boolean;
   onClick: (value: string) => void;
 };
 
 function HeaderTool(headerProps: Props) {
-  const { data, selectedMenu, onClick } = headerProps;
+  const { data, selectedMenu, onClick, isRecommend } = headerProps;
   const { isSelectedSub, breadCrumb, mainCategory } = headerProps;
   const [filterOpen, setFilterOpen] = useState(false);
 
@@ -65,30 +66,32 @@ function HeaderTool(headerProps: Props) {
           <button
             type="button"
             aria-label="상품 검색 버튼"
-            className={$['btn-search']}
+            className={$.search}
           >
             <Search />
           </button>
         </Link>
 
-        <AsyncBoundary
-          suspenseFallback={<FilterSkeleton />}
-          errorFallback={ErrorFallback}
-        >
-          <Button
-            iconBtn
-            label="상품 필터 버튼"
-            className={$.btn}
-            onClick={openFilterModal}
+        {!isRecommend && (
+          <AsyncBoundary
+            suspenseFallback={<FilterSkeleton />}
+            errorFallback={ErrorFallback}
           >
-            <Filter fill="#C9B6FF" stroke="#936DFF" />
-          </Button>
-          <FilterModal
-            {...{ mainCategory }}
-            isOpen={filterOpen}
-            onClose={closeFilterModal}
-          />
-        </AsyncBoundary>
+            <Button
+              iconBtn
+              label="상품 필터 버튼"
+              className={$.filter}
+              onClick={openFilterModal}
+            >
+              <Filter fill="#C9B6FF" stroke="#936DFF" />
+            </Button>
+            <FilterModal
+              {...{ mainCategory }}
+              isOpen={filterOpen}
+              onClose={closeFilterModal}
+            />
+          </AsyncBoundary>
+        )}
       </section>
     </section>
   );

--- a/src/components/Shop/molecules/HeaderTool/style.module.scss
+++ b/src/components/Shop/molecules/HeaderTool/style.module.scss
@@ -17,12 +17,14 @@
     height: 34px;
     display: flex;
     align-items: center;
-    .btn {
+
+    .search {
       display: flex;
-      &-search {
-        display: flex;
-        margin: 0 20px 0 auto;
-      }
+      margin: 0 0 0 auto;
+    }
+    .filter {
+      display: flex;
+      margin-left: 20px;
     }
   }
 }

--- a/src/components/shared/atoms/ErrorFallback/style.module.scss
+++ b/src/components/shared/atoms/ErrorFallback/style.module.scss
@@ -5,6 +5,7 @@
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
+  margin: auto;
   &-box {
     display: flex;
     flex-direction: column;

--- a/src/components/shared/atoms/TextArea/style.module.scss
+++ b/src/components/shared/atoms/TextArea/style.module.scss
@@ -5,6 +5,7 @@
   @include border(border, 5px, $gray-280);
   padding: 16px 19px;
   word-break: break-all;
+  word-wrap: break-word;
   &::placeholder {
     color: $gray-280;
   }

--- a/src/components/shared/atoms/icon/Home.tsx
+++ b/src/components/shared/atoms/icon/Home.tsx
@@ -4,14 +4,14 @@ function Home({ className, style, fill }: IconProps) {
   return (
     <svg
       {...{ className, style }}
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
+      width="20"
+      height="17"
+      viewBox="0 0 20 17"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M10 20V14H14V20H19V12H22L12 3L2 12H5V20H10Z"
+        d="M8 17V11H12V17H17V9H20L10 0L0 9H3V17H8Z"
         fill={fill || 'black'}
         fillOpacity="0.87"
       />

--- a/src/components/shared/molecules/SelectBox/SelectBox.view.tsx
+++ b/src/components/shared/molecules/SelectBox/SelectBox.view.tsx
@@ -1,0 +1,82 @@
+import { forwardRef, LegacyRef } from 'react';
+
+import { SelectArrow } from '@atoms/icon';
+import Span from '@atoms/Span';
+import classnames from 'classnames';
+
+import $ from './style.module.scss';
+
+type Props = {
+  name: string;
+  isClicked: boolean;
+  labelName: string;
+  isGender?: boolean;
+  width?: string;
+  height?: string;
+  fontSize?: number;
+  fontWeight?: number;
+  children?: React.ReactNode;
+  handleMouseDown: (
+    e: React.MouseEvent<HTMLElement> | React.TouchEvent<HTMLElement>,
+  ) => void;
+};
+
+function SelectBoxView(
+  viewProps: Props,
+  ref: LegacyRef<HTMLButtonElement> | null,
+) {
+  const { name, width, height, fontSize, fontWeight, labelName } = viewProps;
+  const { isGender, isClicked, handleMouseDown, children } = viewProps;
+
+  return (
+    <div
+      className={classnames($['select-box'], {
+        [$['select-box-clicked']]: isClicked,
+        [$['gender-box']]: isGender,
+      })}
+      style={{ ...{ width, height } }}
+    >
+      <button
+        id={`${name}-select-box`}
+        ref={ref}
+        type="button"
+        aria-haspopup="true"
+        aria-expanded="true"
+        aria-controls={`${name}-select-list`}
+        onClick={handleMouseDown}
+      >
+        <Span
+          fontSize={fontSize || 16}
+          fontWeight={fontWeight || 400}
+          className={classnames($.text, {
+            [$['gender-text']]: isGender,
+          })}
+        >
+          {labelName || '선택'}
+        </Span>
+        <SelectArrow
+          className={classnames($.arrow, {
+            [$['arrow-clicked']]: isClicked,
+          })}
+        />
+      </button>
+
+      {isClicked && (
+        <ul
+          id={`${name}-select-list`}
+          aria-labelledby={`${name}-select-box`}
+          role="menu"
+          tabIndex={0}
+          style={{ top: height ? `calc(${height} + 6px)` : '56px' }}
+          className={classnames($['select-wrapper'], {
+            [$['select-wrapper-clicked']]: isClicked,
+          })}
+        >
+          {children}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default forwardRef(SelectBoxView);

--- a/src/components/shared/molecules/SelectBox/SelectMenu.view.tsx
+++ b/src/components/shared/molecules/SelectBox/SelectMenu.view.tsx
@@ -10,9 +10,7 @@ type Props = {
   optionName: string;
   height?: string;
   fontSize?: string;
-  handleSelectMenu: (
-    e: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>,
-  ) => void;
+  handleSelectMenu: () => void;
 };
 
 function SelectMenuView(viewProps: Props) {

--- a/src/components/shared/molecules/SelectBox/SelectMenu.view.tsx
+++ b/src/components/shared/molecules/SelectBox/SelectMenu.view.tsx
@@ -1,0 +1,43 @@
+import { Check } from '@atoms/icon';
+import classnames from 'classnames';
+
+import $ from './style.module.scss';
+
+type Props = {
+  isGender?: boolean;
+  isItemSelected: boolean;
+  isGenderItemSelected?: boolean;
+  optionName: string;
+  height?: string;
+  fontSize?: string;
+  handleSelectMenu: (
+    e: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>,
+  ) => void;
+};
+
+function SelectMenuView(viewProps: Props) {
+  const { height, fontSize, isGender, isGenderItemSelected } = viewProps;
+  const { isItemSelected, optionName, handleSelectMenu } = viewProps;
+
+  return (
+    <li
+      tabIndex={0}
+      role="menuitem"
+      style={{ ...{ height } }}
+      className={classnames($['select-item'], {
+        [$['select-item-gender']]: isGender,
+        [$['select-item-clicked']]: isItemSelected,
+        [$['select-hover']]: !isGender,
+        [$['gender-item-clicked']]: isGenderItemSelected,
+        [$['gender-hover']]: isGender,
+      })}
+      onClick={handleSelectMenu}
+      onKeyPress={handleSelectMenu}
+    >
+      <span style={{ fontSize }}>{optionName}</span>
+
+      {isGenderItemSelected && <Check className={$['check-icon']} />}
+    </li>
+  );
+}
+export default SelectMenuView;

--- a/src/components/shared/molecules/SelectBox/index.tsx
+++ b/src/components/shared/molecules/SelectBox/index.tsx
@@ -1,21 +1,16 @@
 import { memo, useRef } from 'react';
 
 import { DefaultData } from '#types/index';
-import { SelectArrow } from '@atoms/icon';
-import Span from '@atoms/Span';
-import classnames from 'classnames';
 
+import SelectBoxView from './SelectBox.view';
 import SelectMenuView from './SelectMenu.view';
-import $ from './style.module.scss';
 import useSelect from './useSelect';
 import { getLabelNameByProp } from './utils';
 
 type Props<T, U> = {
+  name: string;
   options: (string | DefaultData)[];
   selected: string | number;
-  onChange?: (value: string, type: T, subType: U) => void;
-  onQueryChange?: (value: string) => void;
-  name: string;
   type?: T;
   subType?: U;
   width?: string;
@@ -25,20 +20,18 @@ type Props<T, U> = {
   fontSize?: number;
   hasId?: boolean;
   isSameCodeName?: boolean;
+  onChange?: (value: string, type: T, subType: U) => void;
+  onQueryChange?: (value: string) => void;
 };
 
 function SelectBox<T, U>(selectProps: Props<T, U>) {
   const { options, selected, onChange, onQueryChange } = selectProps;
   const { width, height, type, subType, fontWeight, fontSize } = selectProps;
-  const { name, isGender, hasId, isSameCodeName } = selectProps;
-  const labelRef = useRef<HTMLButtonElement>(null);
-  const [isClicked, setIsClicked] = useSelect(labelRef);
+  const { name, isGender, hasId, isSameCodeName: isSame } = selectProps;
+  const ref = useRef<HTMLButtonElement>(null);
+  const [isClicked, setIsClicked] = useSelect(ref);
   const labelProp = hasId ? 'id' : 'code';
-  const labelName = getLabelNameByProp(
-    [options, selected],
-    labelProp,
-    isSameCodeName,
-  );
+  const labelName = getLabelNameByProp([options, selected], labelProp, isSame);
 
   const isGenderSelected = (optionName: string) =>
     isGender && labelName === optionName;
@@ -52,10 +45,7 @@ function SelectBox<T, U>(selectProps: Props<T, U>) {
     setIsClicked((clicked) => !clicked);
   };
 
-  const handleSelectItem = (
-    e: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>,
-    option?: string,
-  ) => {
+  const handleSelectItem = (option?: string) => {
     if (type && subType && option && onChange) {
       onChange(option, type, subType);
     } else if (option && onQueryChange) {
@@ -64,78 +54,43 @@ function SelectBox<T, U>(selectProps: Props<T, U>) {
     setIsClicked(false);
   };
 
+  const viewProps = {
+    name,
+    isClicked,
+    isGender,
+    labelName,
+    width,
+    height,
+    fontSize,
+    fontWeight,
+    handleMouseDown,
+    ref,
+  };
+
   return (
-    <div
-      className={classnames($['select-box'], {
-        [$['select-box-clicked']]: isClicked,
-        [$['gender-box']]: isGender,
+    <SelectBoxView {...viewProps}>
+      {options.map((option) => {
+        const isObject = typeof option === 'object';
+        const candidateName = isObject ? option.name : option;
+        const optionCodeName = isObject ? option.code : option;
+        const optionName = isSame ? optionCodeName : candidateName;
+        const optionData = isObject ? option.code : option;
+        const hasIdData = isObject ? option.id : option;
+        const toBeData = hasId ? hasIdData : optionData;
+
+        const props = {
+          height,
+          fontSize: `${fontSize}px`,
+          isGender,
+          optionName,
+          isItemSelected: isSelected(optionName),
+          isGenderItemSelected: isGenderSelected(optionName),
+          handleSelectMenu: () => handleSelectItem(toBeData),
+        };
+
+        return <SelectMenuView key={props.optionName} {...props} />;
       })}
-      style={{ ...{ width, height } }}
-    >
-      <button
-        id={`${name}-select-box`}
-        ref={labelRef}
-        type="button"
-        aria-haspopup="true"
-        aria-expanded="true"
-        aria-controls={`${name}-select-list`}
-        onClick={handleMouseDown}
-      >
-        <Span
-          fontSize={fontSize || 16}
-          fontWeight={fontWeight || 400}
-          className={classnames($.text, {
-            [$['gender-text']]: isGender,
-          })}
-        >
-          {labelName || '선택'}
-        </Span>
-        <SelectArrow
-          className={classnames($.arrow, {
-            [$['arrow-clicked']]: isClicked,
-          })}
-        />
-      </button>
-
-      {isClicked && (
-        <ul
-          id={`${name}-select-list`}
-          aria-labelledby={`${name}-select-box`}
-          role="menu"
-          tabIndex={0}
-          style={{ top: height ? `calc(${height} + 6px)` : '56px' }}
-          className={classnames($['select-wrapper'], {
-            [$['select-wrapper-clicked']]: isClicked,
-          })}
-        >
-          {options.map((option) => {
-            const isObject = typeof option === 'object';
-            const candidateName = isObject ? option.name : option;
-            const optionCodeName = isObject ? option.code : option;
-            const optionName = isSameCodeName ? optionCodeName : candidateName;
-            const optionData = isObject ? option.code : option;
-            const hasIdData = isObject ? option.id : option;
-            const toBeData = hasId ? hasIdData : optionData;
-
-            const props = {
-              height,
-              fontSize: `${fontSize}px`,
-              isGender,
-              optionName,
-              isItemSelected: isSelected(optionName),
-              isGenderItemSelected: isGenderSelected(optionName),
-              handleSelectMenu: (
-                e:
-                  | React.MouseEvent<HTMLLIElement>
-                  | React.KeyboardEvent<HTMLLIElement>,
-              ) => handleSelectItem(e, toBeData),
-            };
-
-            return <SelectMenuView key={props.optionName} {...props} />;
-          })}
-        </ul>
-      )}
-    </div>
+    </SelectBoxView>
   );
 }
 

--- a/src/components/shared/molecules/SelectBox/utils.ts
+++ b/src/components/shared/molecules/SelectBox/utils.ts
@@ -1,14 +1,16 @@
 import { DefaultData } from '#types/index';
 
 export const getLabelNameByProp = (
-  options: (string | DefaultData)[],
-  selected: string | number,
+  [options, selected]: [(string | DefaultData)[], string | number],
   prop?: keyof DefaultData,
+  isSameCodeName?: boolean,
 ) => {
   let labelName = '선택';
   options.forEach((option) => {
     if (typeof option !== 'string' && prop) {
-      if (option[prop]?.toString() === selected) labelName = option.name;
+      const isSameLabel = option[prop]?.toString() === selected;
+      if (isSameLabel && isSameCodeName) labelName = option.code;
+      else if (isSameLabel) labelName = option.name;
     }
     if (option === selected) labelName = option;
   });

--- a/src/components/shared/templates/DialogModal/style.module.scss
+++ b/src/components/shared/templates/DialogModal/style.module.scss
@@ -19,6 +19,7 @@
     @include typography(18);
     font-weight: 700;
     color: $black-600;
+    word-break: break-all;
     &:visited {
       color: $primary;
     }

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,9 +1,9 @@
 import { useRouter } from 'next/router';
 
-import { getQueryStringObj, getQueriesArr } from 'src/utils';
+import { getQueryStringObj, getQueriesArr, getPropFromQuery } from 'src/utils';
 
 function useSearch(target: string) {
-  return useRouter().query[target]?.toString() || '';
+  return getPropFromQuery(useRouter().asPath.split('?')[1], target) || '';
 }
 
 function useMultipleSearch<T extends string>(
@@ -14,7 +14,9 @@ function useMultipleSearch<T extends string>(
   return getQueryStringObj(
     getQueriesArr<T>(
       queryDatas,
-      targets.map((target) => router.query[target]),
+      targets.map(
+        (target) => getPropFromQuery(router.asPath.split('?')[1], target) || '',
+      ),
     ),
   );
 }

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -3,20 +3,21 @@ import { useRouter } from 'next/router';
 import { getQueryStringObj, getQueriesArr, getPropFromQuery } from 'src/utils';
 
 function useSearch(target: string) {
-  return getPropFromQuery(useRouter().asPath.split('?')[1], target) || '';
+  const { pathname, asPath } = useRouter();
+  const query = asPath.replace(pathname, '');
+  return getPropFromQuery(query, target) || '';
 }
 
 function useMultipleSearch<T extends string>(
   queryDatas: [T, string?][],
   targets: readonly string[],
 ) {
-  const router = useRouter();
+  const { pathname, asPath } = useRouter();
+  const query = asPath.replace(pathname, '');
   return getQueryStringObj(
     getQueriesArr<T>(
       queryDatas,
-      targets.map(
-        (target) => getPropFromQuery(router.asPath.split('?')[1], target) || '',
-      ),
+      targets.map((target) => getPropFromQuery(query, target) || ''),
     ),
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,7 +21,7 @@ function Main() {
         url={`${seoData.url}`}
       />
 
-      <section className={$['on-boarding']}>
+      <section className={$.main}>
         <MainHeader />
 
         <TodayRecommend />

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -69,7 +69,6 @@ function SearchPage() {
         }}
       />
       <SearchBody {...{ value, queryStringObj }} />
-      <Footer />
     </>
   );
 }

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -6,7 +6,6 @@ import HeadMeta from '@atoms/HeadMeta';
 import { searchQueries, searchQueryData } from '@constants/queryString';
 import { queryKey } from '@constants/react-query';
 import { seoData } from '@constants/seo';
-import Footer from '@organisms/Footer';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import Layout from '@templates/Layout';
 import { withGetServerSideProps } from 'src/api/core/withGetServerSideProps';

--- a/src/pages/shop/index.tsx
+++ b/src/pages/shop/index.tsx
@@ -84,6 +84,7 @@ function Shop() {
     genderSelectMenu,
     selectData,
     breadCrumb,
+    isRecommend,
   };
 
   return (

--- a/src/pages/upload/update/index.tsx
+++ b/src/pages/upload/update/index.tsx
@@ -10,9 +10,9 @@ import Layout from '@templates/Layout';
 import UploadTemplate from '@templates/UploadTemplate';
 import { getSelectedCategory } from 'src/api/category';
 import { getStaticData } from 'src/api/staticData';
+import { useSearch } from 'src/hooks';
 import { useUploadedProduct } from 'src/hooks/api/upload';
 import { useUploadUpdateStore } from 'src/store/upload/useUploadUpdateStore';
-import { getPropFromQuery } from 'src/utils';
 import { toastError } from 'src/utils/toaster';
 import { uploadedDataToState } from 'src/utils/upload.utils';
 
@@ -52,9 +52,8 @@ export const getStaticProps = async () => {
 };
 
 function UploadUpdate() {
-  const { asPath, replace } = useRouter();
-  const searchParams = asPath.split('?')[1];
-  const id = getPropFromQuery(searchParams, 'id') || '';
+  const { replace } = useRouter();
+  const id = useSearch('id');
   const { data, isSuccess } = useUploadedProduct(id);
   const states = useUploadUpdateStore((state) => state);
   const { initState } = states;

--- a/src/styles/index.module.scss
+++ b/src/styles/index.module.scss
@@ -1,12 +1,6 @@
-.on-boarding {
+.main {
   position: relative;
   min-height: calc(var(--vh, 1vh) * 100);
   display: flex;
   flex-direction: column;
-
-  .decription {
-    z-index: 1;
-    font-weight: 600;
-    @include typography(13);
-  }
 }

--- a/src/utils/timeForToday.ts
+++ b/src/utils/timeForToday.ts
@@ -1,6 +1,6 @@
 export const timeForToday = (value: string) => {
   const today = new Date();
-  const timeValue = new Date(value);
+  const timeValue = new Date(value.replace(/-/g, '/'));
 
   const betweenTime = Math.floor(
     (today.getTime() - timeValue.getTime()) / 1000 / 60,


### PR DESCRIPTION
## 💡 이슈
resolve #{이슈번호}

## 🤩 개요
PR의 개요를 적어주세요.

## 🧑‍💻 작업 사항

- [x]  검색 페이지 Footer 제거
- [x]  사파리에서 date 이슈(-포맷이 적용되지 않아 /로 변경)
- [x]  Home아이콘 크기 맞추기
- [x]  로그인 시 이전 history(oauth 페이지) 제거
- [x]  추천 카테고리에서 필터 제외시키기
- [x]  useRouter().query 이슈 해결
- [x]  shop 피드 gender한글에서 영어로 변경하기 및 SelectBox 리팩토링

## 📖 참고 사항
### useRouter().query 가 첫 렌더링 시 빈 객체({})로 인한 불필요한 리렌더링 발생

### As-Is

https://user-images.githubusercontent.com/62797441/202069015-652bb252-45ea-433a-9633-be7a6f05fa3d.mov

![스크린샷 2022-11-16 오전 6 58 47](https://user-images.githubusercontent.com/62797441/202069283-a2b4bb0d-4017-4f80-b05f-5b174282d686.png)

![스크린샷 2022-11-16 오전 6 56 39](https://user-images.githubusercontent.com/62797441/202069238-a2358453-32f4-4e72-b535-82a12bfb3826.png)

영상에서 보면 리렌더링이 발생합니다. 이로 인해 불필요한 api 요청 또한 발생합니다.

### To-Be
https://user-images.githubusercontent.com/62797441/202068999-6429be09-40ec-4ee4-a920-8d25218827d8.mov

![스크린샷 2022-11-16 오전 11 55 13](https://user-images.githubusercontent.com/62797441/202072353-d8b8ceaf-08d7-4fa1-9a71-c13d8c91b096.png)

![스크린샷 2022-11-16 오전 11 54 20](https://user-images.githubusercontent.com/62797441/202072362-38c9ddf3-3902-4e8c-b700-95afddd354bd.png)

따라서 이와 같이 개선하였습니다.

``` ts
function useSearch(target: string) {
  const { pathname, asPath } = useRouter();
  const query = asPath.replace(pathname, '');
  return getPropFromQuery(query, target) || '';
}
```

구현 코드는 다음과 같습니다. `getPropFromQuery`라는 유틸 함수를 재사용했고 이 함수는 `new URLSearchParams(query).get(target)`로 동작합니다. 

처음에는 `useRouter().asPath`를 인수로 넣었지만 `/shop?category=1999&hideSold=false`에서 ? 바로 뒤에 있는 `category`의 경우 인식을 못한다는 이슈가 있었습니다. 따라서 `const query = asPath.replace(pathname, '');`와 같이 첫번째로 등장하는 pathname을 제거하여 해결하였습니다. `pathname`에는 /가 포함되어 있고 `asPath`의 맨 앞부분에는 `pathname`이 포함되어 있고 `pathname`은 url에서 다시 등장할 일은 없기 때문에 첫번째 `pathname`만 제거했습니다. 이 부분은 이후 테스트 코드 작성을 통해 잔여 이슈를 해결해갈 예정입니다.