### PR TITLE
[Feat] 상품 업로드 페이지 리팩토링

### DIFF
--- a/src/components/Upload/organisms/AdditionInfo/index.tsx
+++ b/src/components/Upload/organisms/AdditionInfo/index.tsx
@@ -9,6 +9,7 @@ import TextArea from '@atoms/TextArea';
 import InfoArticle from '@molecules/InfoArticle';
 import TextInput from '@molecules/TextInput';
 import useDebounceInput from 'src/hooks/useDebounceInput';
+import { useUploadStore } from 'src/store/upload/useUploadStore';
 
 import $ from './style.module.scss';
 
@@ -20,14 +21,13 @@ type Props = {
     subType: keyof AdditionalInfo;
   }[];
   opinionPlaceholder: string;
-  opinionState: UploadState['opinion'];
-  additionState: UploadState['additionalInfo'];
   onChange: UpdateUpload;
 };
 
 function AdditionInfo(additionProps: Props) {
   const { data: datas, opinionPlaceholder, onChange } = additionProps;
-  const { additionState, opinionState } = additionProps;
+  const opinion = useUploadStore((states) => states.opinion);
+  const additionalInfo = useUploadStore((states) => states.additionalInfo);
   const handleInput = useDebounceInput(onChange, 200);
 
   const handleChange = useCallback(
@@ -53,7 +53,7 @@ function AdditionInfo(additionProps: Props) {
               key={label}
               className={$.addition}
               controlled={false}
-              value={additionState[subType]}
+              value={additionalInfo[subType]}
               {...{ label, placeholder, subType }}
               onChange={handleChange}
             />
@@ -65,7 +65,7 @@ function AdditionInfo(additionProps: Props) {
           className={$.textarea}
           color="#e3e1e1"
           placeholder={opinionPlaceholder}
-          value={opinionState}
+          value={opinion}
           onChange={handleOpinionChange}
         />
       </InfoArticle>

--- a/src/components/Upload/organisms/Basic/index.tsx
+++ b/src/components/Upload/organisms/Basic/index.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useState } from 'react';
 
-import { UpdateUpload, UploadState } from '#types/storeType/upload';
+import { UpdateUpload } from '#types/storeType/upload';
 import Button from '@atoms/Button';
 import ErrorMsg from '@atoms/ErrorMsg';
 import { SelectArrow } from '@atoms/icon';
@@ -8,22 +8,22 @@ import InfoArticle from '@molecules/InfoArticle';
 import TextInput from '@molecules/TextInput';
 import { getBreadcrumb, getCategoryTree } from 'src/api/category';
 import useDebounceInput from 'src/hooks/useDebounceInput';
+import { useUploadStore } from 'src/store/upload/useUploadStore';
 
 import Dialog from '../Dialog';
 import { dialogCategoryProps } from '../Dialog/utils';
 import $ from './style.module.scss';
 
 type Props = {
-  state: UploadState['basicInfo'];
   categoryData: res.CategoryTree['data'];
   onChange: UpdateUpload;
   isBasicValid: boolean;
 };
 
 function Basic(basicProps: Props) {
-  const { state, onChange } = basicProps;
+  const { onChange, categoryData, isBasicValid } = basicProps;
+  const state = useUploadStore((states) => states.basicInfo);
   const { category, curCategoryIdx } = state;
-  const { categoryData, isBasicValid } = basicProps;
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const openDialog = useCallback(() => setDialogOpen(true), []);

--- a/src/components/Upload/organisms/Basic/index.tsx
+++ b/src/components/Upload/organisms/Basic/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useState } from 'react';
+import { memo, useCallback, useEffect, useState } from 'react';
 
 import { UpdateUpload } from '#types/storeType/upload';
 import Button from '@atoms/Button';
@@ -13,17 +13,23 @@ import { useUploadStore } from 'src/store/upload/useUploadStore';
 import Dialog from '../Dialog';
 import { dialogCategoryProps } from '../Dialog/utils';
 import $ from './style.module.scss';
+import { basicValidate } from './validate';
 
 type Props = {
   categoryData: res.CategoryTree['data'];
   onChange: UpdateUpload;
-  isBasicValid: boolean;
 };
 
 function Basic(basicProps: Props) {
-  const { onChange, categoryData, isBasicValid } = basicProps;
+  const { onChange, categoryData } = basicProps;
   const state = useUploadStore((states) => states.basicInfo);
+  const updateValidate = useUploadStore((states) => states.updateValidate);
   const { category, curCategoryIdx } = state;
+  const isBasicValid = basicValidate(state);
+
+  useEffect(() => {
+    updateValidate('basicInfo', isBasicValid);
+  }, [isBasicValid, updateValidate]);
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const openDialog = useCallback(() => setDialogOpen(true), []);

--- a/src/components/Upload/organisms/Basic/validate.ts
+++ b/src/components/Upload/organisms/Basic/validate.ts
@@ -1,0 +1,8 @@
+import { UploadState } from '#types/storeType/upload';
+
+export const basicValidate = (basic: UploadState['basicInfo']) => {
+  const titleValid = !!basic.title;
+  const categoryValid = !!basic.category.every((x) => !!x);
+  const brandValid = !!basic.brand;
+  return titleValid && categoryValid && brandValid;
+};

--- a/src/components/Upload/organisms/Contact/index.tsx
+++ b/src/components/Upload/organisms/Contact/index.tsx
@@ -1,6 +1,6 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useEffect } from 'react';
 
-import { UpdateUpload, UploadState } from '#types/storeType/upload';
+import { UpdateUpload } from '#types/storeType/upload';
 import ErrorMsg from '@atoms/ErrorMsg';
 import InfoArticle from '@molecules/InfoArticle';
 import TextInput from '@molecules/TextInput';
@@ -8,15 +8,17 @@ import useDebounceInput from 'src/hooks/useDebounceInput';
 import { useUploadStore } from 'src/store/upload/useUploadStore';
 
 import $ from './style.module.scss';
+import { contactValidate } from './validate';
 
 type Props = {
   onChange: UpdateUpload;
-  isContactValid: boolean;
 };
 
 function Contact(contactProps: Props) {
-  const { onChange, isContactValid } = contactProps;
+  const { onChange } = contactProps;
   const state = useUploadStore((states) => states.contact);
+  const updateValidate = useUploadStore((states) => states.updateValidate);
+  const isContactValid = contactValidate(state);
   const handleInput = useDebounceInput(onChange, 200);
 
   const handleChange = useCallback(
@@ -24,6 +26,10 @@ function Contact(contactProps: Props) {
       handleInput(e.target.value, 'contact'),
     [handleInput],
   );
+
+  useEffect(() => {
+    updateValidate('contact', isContactValid);
+  }, [isContactValid, updateValidate]);
 
   return (
     <InfoArticle

--- a/src/components/Upload/organisms/Contact/index.tsx
+++ b/src/components/Upload/organisms/Contact/index.tsx
@@ -5,18 +5,18 @@ import ErrorMsg from '@atoms/ErrorMsg';
 import InfoArticle from '@molecules/InfoArticle';
 import TextInput from '@molecules/TextInput';
 import useDebounceInput from 'src/hooks/useDebounceInput';
+import { useUploadStore } from 'src/store/upload/useUploadStore';
 
 import $ from './style.module.scss';
 
 type Props = {
-  state: UploadState['contact'];
   onChange: UpdateUpload;
   isContactValid: boolean;
 };
 
 function Contact(contactProps: Props) {
-  const { state, onChange, isContactValid } = contactProps;
-
+  const { onChange, isContactValid } = contactProps;
+  const state = useUploadStore((states) => states.contact);
   const handleInput = useDebounceInput(onChange, 200);
 
   const handleChange = useCallback(

--- a/src/components/Upload/organisms/Contact/validate.ts
+++ b/src/components/Upload/organisms/Contact/validate.ts
@@ -1,0 +1,5 @@
+import { UploadState } from '#types/storeType/upload';
+
+export const contactValidate = (contact: UploadState['contact']) => {
+  return !!contact;
+};

--- a/src/components/Upload/organisms/Dialog/index.tsx
+++ b/src/components/Upload/organisms/Dialog/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { BasicInfo, UpdateUpload } from '#types/storeType/upload';
 import Button from '@atoms/Button';
@@ -123,4 +123,4 @@ function DialogWrapper(dialogProps: Props) {
   );
 }
 
-export default memo(DialogWrapper);
+export default DialogWrapper;

--- a/src/components/Upload/organisms/Dialog/index.tsx
+++ b/src/components/Upload/organisms/Dialog/index.tsx
@@ -31,8 +31,6 @@ function Dialog(dialogProps: Omit<Props, 'isOpen'>) {
   const isValidPrevBtn = curCategoryIdx !== 0 && category[curCategoryIdx - 1];
   const lastBtnText = curCategoryIdx === category.length - 1 ? '완료' : '다음';
   const pageNum = `${curCategoryIdx + 1}/${category.length}`;
-  const prevBtnColor = !isValidPrevBtn ? '#e3e1e1' : '#000';
-  const nextBtnColor = !isCurValueExist ? '#e3e1e1' : '#000';
 
   useEffect(() => {
     return () => {
@@ -84,21 +82,17 @@ function Dialog(dialogProps: Omit<Props, 'isOpen'>) {
         </div>
 
         <ButtonFooter
+          disabled={!isCurValueExist}
           LeftBtn={
             <Button
-              background={prevBtnColor}
               className={$.prev}
-              onClick={() => {
-                if (isValidPrevBtn) prevBtn(curCategoryIdx);
-              }}
+              disabled={!isValidPrevBtn}
+              onClick={() => prevBtn(curCategoryIdx)}
             >
               이전
             </Button>
           }
-          btnColor={nextBtnColor}
-          onClick={() => {
-            if (isCurValueExist) nextBtn(curCategoryIdx);
-          }}
+          onClick={() => nextBtn(curCategoryIdx)}
         >
           {lastBtnText}
         </ButtonFooter>

--- a/src/components/Upload/organisms/ImgUpload/index.tsx
+++ b/src/components/Upload/organisms/ImgUpload/index.tsx
@@ -1,32 +1,28 @@
 import { memo, useCallback, useRef, useState } from 'react';
 
-import {
-  ImgList,
-  UpdateArr,
-  UpdateUpload,
-  UploadStoreState,
-} from '#types/storeType/upload';
+import { UpdateUpload } from '#types/storeType/upload';
 import { recognitionResult } from '#types/upload';
 import { getCategoryIds } from 'src/api/category';
 import { useImgUpload } from 'src/hooks/api/upload';
 import useSwiper from 'src/hooks/useSwiper';
+import { useUploadStore } from 'src/store/upload/useUploadStore';
 
 import ImgUploadView from './ImgUploadView';
 import { getFormData, imageList } from './utils';
 
 type Props = {
   isImgValid: boolean;
-  state: ImgList[];
   categoryData: res.CategoryTree['data'];
-  imgUpload: UploadStoreState['imgUpload'];
-  removeImg: UploadStoreState['removeImg'];
   onChange: UpdateUpload;
-  updateArr: UpdateArr;
 };
 
 function ImgUpload(imgProps: Props) {
-  const { onChange, imgUpload, removeImg, updateArr } = imgProps;
-  const { state, isImgValid, categoryData } = imgProps;
+  const { onChange } = imgProps;
+  const { isImgValid, categoryData } = imgProps;
+  const imgList = useUploadStore((states) => states.imgList);
+  const updateArr = useUploadStore((states) => states.updateArr);
+  const imgUpload = useUploadStore((states) => states.imgUpload);
+  const removeImg = useUploadStore((states) => states.removeImg);
   const [imgResult, setImgResult] = useState<recognitionResult>({});
   const inputRef = useRef<HTMLInputElement>(null);
   const uploadRef = useRef<HTMLDivElement>(null);
@@ -78,7 +74,7 @@ function ImgUpload(imgProps: Props) {
     isImgValid,
     uploadRef,
     inputRef,
-    state,
+    state: imgList,
     imgResult,
     onUploadClick,
     onUploadImg,

--- a/src/components/Upload/organisms/ImgUpload/index.tsx
+++ b/src/components/Upload/organisms/ImgUpload/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 
 import { UpdateUpload } from '#types/storeType/upload';
 import { recognitionResult } from '#types/upload';
@@ -9,25 +9,31 @@ import { useUploadStore } from 'src/store/upload/useUploadStore';
 
 import ImgUploadView from './ImgUploadView';
 import { getFormData, imageList } from './utils';
+import { imgListValidate } from './validate';
 
 type Props = {
-  isImgValid: boolean;
   categoryData: res.CategoryTree['data'];
   onChange: UpdateUpload;
 };
 
 function ImgUpload(imgProps: Props) {
   const { onChange } = imgProps;
-  const { isImgValid, categoryData } = imgProps;
+  const { categoryData } = imgProps;
   const imgList = useUploadStore((states) => states.imgList);
   const updateArr = useUploadStore((states) => states.updateArr);
   const imgUpload = useUploadStore((states) => states.imgUpload);
   const removeImg = useUploadStore((states) => states.removeImg);
+  const updateValidate = useUploadStore((states) => states.updateValidate);
   const [imgResult, setImgResult] = useState<recognitionResult>({});
   const inputRef = useRef<HTMLInputElement>(null);
   const uploadRef = useRef<HTMLDivElement>(null);
   const { isLoading, mutate } = useImgUpload();
+  const isImgValid = imgListValidate(imgList);
+
   useSwiper(uploadRef);
+  useEffect(() => {
+    updateValidate('imgList', isImgValid);
+  }, [isImgValid, updateValidate]);
 
   const onUploadClick = useCallback(() => {
     if (inputRef.current) inputRef.current.click();

--- a/src/components/Upload/organisms/ImgUpload/validate.ts
+++ b/src/components/Upload/organisms/ImgUpload/validate.ts
@@ -1,0 +1,5 @@
+import { UploadState } from '#types/storeType/upload';
+
+export const imgListValidate = (imgList: UploadState['imgList']) => {
+  return !!imgList.length;
+};

--- a/src/components/Upload/organisms/MeasureInfo/index.tsx
+++ b/src/components/Upload/organisms/MeasureInfo/index.tsx
@@ -1,21 +1,22 @@
 import { memo, useCallback } from 'react';
 
 import { DefaultData } from '#types/index';
-import { Measure, UpdateUpload, UploadState } from '#types/storeType/upload';
+import { Measure, UpdateUpload } from '#types/storeType/upload';
 import InfoArticle from '@molecules/InfoArticle';
 import TextInput from '@molecules/TextInput';
+import { useUploadStore } from 'src/store/upload/useUploadStore';
 import { filterHeight } from 'src/utils/filterValue';
 
 import $ from './style.module.scss';
 
 type Props = {
   data: DefaultData[];
-  state: UploadState['measure'];
   onChange: UpdateUpload;
 };
 
 function MeasureInfo(priceProps: Props) {
-  const { data, state, onChange } = priceProps;
+  const { data, onChange } = priceProps;
+  const state = useUploadStore((states) => states.measure);
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>, subType?: keyof Measure) => {
       const value = filterHeight(e.target.value);

--- a/src/components/Upload/organisms/Price/index.tsx
+++ b/src/components/Upload/organisms/Price/index.tsx
@@ -9,20 +9,22 @@ import TextInput from '@molecules/TextInput';
 import classnames from 'classnames';
 import { max } from 'src/components/Shop/Organisms/FilterModal/constants';
 import useDebounceInput from 'src/hooks/useDebounceInput';
+import { useUploadStore } from 'src/store/upload/useUploadStore';
 import { filterMaxPrice } from 'src/utils';
 
 import $ from './style.module.scss';
 
 type Props = {
-  state: UploadState['price'];
-  delivery: boolean;
   onChange: UpdateUpload;
   isPriceValid: boolean;
 };
 
 function Price(priceProps: Props) {
-  const { delivery, onChange, state, isPriceValid } = priceProps;
-
+  const { onChange, isPriceValid } = priceProps;
+  const price = useUploadStore((states) => states.price);
+  const isIncludeDelivery = useUploadStore(
+    (states) => states.isIncludeDelivery,
+  );
   const handleInput = useDebounceInput<[number, keyof UploadState, undefined]>(
     onChange,
     200,
@@ -41,7 +43,7 @@ function Price(priceProps: Props) {
       <div className={$.box}>
         <TextInput
           controlled={false}
-          value={state.toString()}
+          value={price.toString()}
           placeholder="판매할 가격을 입력해주세요."
           onChange={handleChange}
         />
@@ -52,7 +54,7 @@ function Price(priceProps: Props) {
 
       <div className={classnames($.box, $.delivery)}>
         <RadioBtn
-          isClicked={delivery}
+          isClicked={isIncludeDelivery}
           onTypeClick={onChange}
           type="isIncludeDelivery"
         />

--- a/src/components/Upload/organisms/Price/index.tsx
+++ b/src/components/Upload/organisms/Price/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useEffect } from 'react';
 
 import { UpdateUpload, UploadState } from '#types/storeType/upload';
 import ErrorMsg from '@atoms/ErrorMsg';
@@ -13,18 +13,19 @@ import { useUploadStore } from 'src/store/upload/useUploadStore';
 import { filterMaxPrice } from 'src/utils';
 
 import $ from './style.module.scss';
+import { priceValidate } from './validate';
 
 type Props = {
   onChange: UpdateUpload;
-  isPriceValid: boolean;
 };
 
-function Price(priceProps: Props) {
-  const { onChange, isPriceValid } = priceProps;
+function Price({ onChange }: Props) {
   const price = useUploadStore((states) => states.price);
+  const isPriceValid = priceValidate(price);
   const isIncludeDelivery = useUploadStore(
     (states) => states.isIncludeDelivery,
   );
+  const updateValidate = useUploadStore((states) => states.updateValidate);
   const handleInput = useDebounceInput<[number, keyof UploadState, undefined]>(
     onChange,
     200,
@@ -37,6 +38,10 @@ function Price(priceProps: Props) {
     },
     [handleInput],
   );
+
+  useEffect(() => {
+    updateValidate('price', isPriceValid);
+  }, [isPriceValid, updateValidate]);
 
   return (
     <InfoArticle label="판매가격 설정" required>

--- a/src/components/Upload/organisms/Price/validate.ts
+++ b/src/components/Upload/organisms/Price/validate.ts
@@ -1,0 +1,5 @@
+import { UploadState } from '#types/storeType/upload';
+
+export const priceValidate = (price: UploadState['price']) => {
+  return !!price;
+};

--- a/src/components/Upload/organisms/SellerReview/index.tsx
+++ b/src/components/Upload/organisms/SellerReview/index.tsx
@@ -1,13 +1,14 @@
 import { memo, useCallback } from 'react';
 
 import { DefaultData } from '#types/index';
-import { UpdateUpload, UploadState } from '#types/storeType/upload';
+import { UpdateUpload } from '#types/storeType/upload';
 import ErrorMsg from '@atoms/ErrorMsg';
 import Span from '@atoms/Span';
 import InfoArticle from '@molecules/InfoArticle';
 import SelectBox from '@molecules/SelectBox';
 import TextInput from '@molecules/TextInput';
 import useDebounceInput from 'src/hooks/useDebounceInput';
+import { useUploadStore } from 'src/store/upload/useUploadStore';
 import { filterHeight } from 'src/utils/filterValue';
 
 import { reviewProps } from './constants';
@@ -21,14 +22,14 @@ type Props = {
     bodyShapes: DefaultData[];
     length: DefaultData[];
   };
-  state: UploadState['sellerNote'];
   onChange: UpdateUpload;
   isSellerValid: boolean;
 };
 
 function SellerReview(priceProps: Props) {
-  const { data, state, onChange, isSellerValid } = priceProps;
+  const { data, onChange, isSellerValid } = priceProps;
   const { condition, pollution, fit, bodyShapes, length } = data;
+  const state = useUploadStore((states) => states.sellerNote);
   const optionsData = [condition, pollution, length, fit];
   const handleInput = useDebounceInput(onChange, 200);
   const handleChange = useCallback(

--- a/src/components/Upload/organisms/SellerReview/index.tsx
+++ b/src/components/Upload/organisms/SellerReview/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useEffect } from 'react';
 
 import { DefaultData } from '#types/index';
 import { UpdateUpload } from '#types/storeType/upload';
@@ -13,6 +13,7 @@ import { filterHeight } from 'src/utils/filterValue';
 
 import { reviewProps } from './constants';
 import $ from './style.module.scss';
+import { sellerReviewValidate } from './validate';
 
 type Props = {
   data: {
@@ -23,14 +24,15 @@ type Props = {
     length: DefaultData[];
   };
   onChange: UpdateUpload;
-  isSellerValid: boolean;
 };
 
-function SellerReview(priceProps: Props) {
-  const { data, onChange, isSellerValid } = priceProps;
+function SellerReview({ data, onChange }: Props) {
   const { condition, pollution, fit, bodyShapes, length } = data;
   const state = useUploadStore((states) => states.sellerNote);
+  const updateValidate = useUploadStore((states) => states.updateValidate);
+  const isSellerValid = sellerReviewValidate(state);
   const optionsData = [condition, pollution, length, fit];
+
   const handleInput = useDebounceInput(onChange, 200);
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -40,6 +42,10 @@ function SellerReview(priceProps: Props) {
     },
     [handleInput],
   );
+
+  useEffect(() => {
+    updateValidate('sellerNote', isSellerValid);
+  }, [isSellerValid, updateValidate]);
 
   return (
     <InfoArticle label="쉽게 작성하는 후기" required>

--- a/src/components/Upload/organisms/SellerReview/validate.ts
+++ b/src/components/Upload/organisms/SellerReview/validate.ts
@@ -1,0 +1,5 @@
+import { UploadState } from '#types/storeType/upload';
+
+export const sellerReviewValidate = (sellerNote: UploadState['sellerNote']) => {
+  return Object.values(sellerNote).every((x) => !!x);
+};

--- a/src/components/Upload/organisms/SizeInfo.tsx
+++ b/src/components/Upload/organisms/SizeInfo.tsx
@@ -1,19 +1,20 @@
 import { memo } from 'react';
 
-import { UpdateUpload, UploadState } from '#types/storeType/upload';
+import { UpdateUpload } from '#types/storeType/upload';
 import ErrorMsg from '@atoms/ErrorMsg';
 import { sizeBtnBox } from '@constants/upload/utils';
 import InfoBtnBox from '@organisms/InfoBtnBox';
+import { useUploadStore } from 'src/store/upload/useUploadStore';
 
 type Props = {
   sizeProps: sizeBtnBox;
-  state: UploadState['size'];
   onChange: UpdateUpload;
   isSizeValid: boolean;
 };
 
 function SizeInfo(infoProps: Props) {
-  const { sizeProps, state, onChange, isSizeValid } = infoProps;
+  const { sizeProps, onChange, isSizeValid } = infoProps;
+  const state = useUploadStore((states) => states.size);
   return (
     <InfoBtnBox
       {...sizeProps}

--- a/src/components/Upload/organisms/SizeInfo/index.tsx
+++ b/src/components/Upload/organisms/SizeInfo/index.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useEffect } from 'react';
 
 import { UpdateUpload } from '#types/storeType/upload';
 import ErrorMsg from '@atoms/ErrorMsg';
@@ -6,15 +6,23 @@ import { sizeBtnBox } from '@constants/upload/utils';
 import InfoBtnBox from '@organisms/InfoBtnBox';
 import { useUploadStore } from 'src/store/upload/useUploadStore';
 
+import { sizeValidate } from './validate';
+
 type Props = {
   sizeProps: sizeBtnBox;
   onChange: UpdateUpload;
-  isSizeValid: boolean;
 };
 
 function SizeInfo(infoProps: Props) {
-  const { sizeProps, onChange, isSizeValid } = infoProps;
+  const { sizeProps, onChange } = infoProps;
   const state = useUploadStore((states) => states.size);
+  const updateValidate = useUploadStore((states) => states.updateValidate);
+  const isSizeValid = sizeValidate(state);
+
+  useEffect(() => {
+    updateValidate('size', isSizeValid);
+  }, [isSizeValid, updateValidate]);
+
   return (
     <InfoBtnBox
       {...sizeProps}

--- a/src/components/Upload/organisms/SizeInfo/validate.ts
+++ b/src/components/Upload/organisms/SizeInfo/validate.ts
@@ -1,0 +1,5 @@
+import { UploadState } from '#types/storeType/upload';
+
+export const sizeValidate = (size: UploadState['size']) => {
+  return !!size;
+};

--- a/src/components/Upload/organisms/StyleSelect/index.tsx
+++ b/src/components/Upload/organisms/StyleSelect/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useEffect } from 'react';
 
 import { DefaultData } from '#types/index';
 import { btnTemplateBox } from '#types/info';
@@ -15,6 +15,7 @@ import useDebounceInput from 'src/hooks/useDebounceInput';
 import { useUploadStore } from 'src/store/upload/useUploadStore';
 
 import $ from './style.module.scss';
+import { styleValidate } from './validate';
 
 type btnBox = btnTemplateBox<keyof UploadState, keyof StyleUpload> & {
   datas: (string | DefaultData)[];
@@ -24,19 +25,24 @@ type btnBox = btnTemplateBox<keyof UploadState, keyof StyleUpload> & {
 type Props = {
   data: btnBox[];
   onChange: UpdateUpload;
-  isStyleValid: boolean;
 };
 
 function StyleSelect(styleProps: Props) {
-  const { data, onChange, isStyleValid } = styleProps;
+  const { data, onChange } = styleProps;
   const handleInput = useDebounceInput(onChange, 200);
   const state = useUploadStore((states) => states.style);
+  const isStyleValid = styleValidate(state);
+  const updateValidate = useUploadStore((states) => states.updateValidate);
   const handleChange = useCallback(
     // Todo: 성능 최적화
     (e: React.ChangeEvent<HTMLInputElement>) =>
       onChange(e.target.value, 'style', 'material'),
     [onChange],
   );
+
+  useEffect(() => {
+    updateValidate('style', isStyleValid);
+  }, [isStyleValid, updateValidate]);
 
   return (
     <InfoArticle

--- a/src/components/Upload/organisms/StyleSelect/index.tsx
+++ b/src/components/Upload/organisms/StyleSelect/index.tsx
@@ -12,6 +12,7 @@ import InfoArticle from '@molecules/InfoArticle';
 import TextInput from '@molecules/TextInput';
 import InfoBtnBox from '@organisms/InfoBtnBox';
 import useDebounceInput from 'src/hooks/useDebounceInput';
+import { useUploadStore } from 'src/store/upload/useUploadStore';
 
 import $ from './style.module.scss';
 
@@ -22,15 +23,14 @@ type btnBox = btnTemplateBox<keyof UploadState, keyof StyleUpload> & {
 
 type Props = {
   data: btnBox[];
-  state: UploadState['style'];
   onChange: UpdateUpload;
   isStyleValid: boolean;
 };
 
 function StyleSelect(styleProps: Props) {
-  const { data, state, onChange, isStyleValid } = styleProps;
+  const { data, onChange, isStyleValid } = styleProps;
   const handleInput = useDebounceInput(onChange, 200);
-
+  const state = useUploadStore((states) => states.style);
   const handleChange = useCallback(
     // Todo: 성능 최적화
     (e: React.ChangeEvent<HTMLInputElement>) =>

--- a/src/components/Upload/organisms/StyleSelect/validate.ts
+++ b/src/components/Upload/organisms/StyleSelect/validate.ts
@@ -1,0 +1,8 @@
+import { StyleUpload } from '#types/storeType/upload';
+
+export const styleValidate = (values: StyleUpload) => {
+  const colorValid = !!values.color.length;
+  const tagValid = !!values.tag;
+  const materialValid = !!values.material;
+  return colorValid && tagValid && materialValid;
+};

--- a/src/components/shared/atoms/Button/Button.stories.tsx
+++ b/src/components/shared/atoms/Button/Button.stories.tsx
@@ -34,6 +34,11 @@ export default {
         type: 'text',
       },
     },
+    disabled: {
+      control: {
+        type: 'boolean',
+      },
+    },
   },
 } as ComponentMeta<typeof Button>;
 
@@ -46,6 +51,7 @@ Default.args = {
   hasErrorMsg: false,
   iconBtn: false,
   children: '버튼 텍스트',
+  disabled: false,
   style: {
     padding: '3px 6px',
   },

--- a/src/components/shared/atoms/Button/Button.view.tsx
+++ b/src/components/shared/atoms/Button/Button.view.tsx
@@ -5,22 +5,25 @@ import classnames from 'classnames';
 
 import $ from './style.module.scss';
 
-type Props = {
+export type ButtonProps = {
   handleClick?: () => void;
-  customStyle: CSSProperties;
-  className?: string;
   iconBtn?: boolean;
   hasErrorMsg?: boolean;
-  ariaLabel: string;
-  children: React.ReactNode;
+  disabled?: boolean;
 } & DefaultProps;
+
+type Props = {
+  customStyle: CSSProperties;
+  ariaLabel: string;
+} & ButtonProps;
 
 function ButtonView(btnProps: Props) {
   const { iconBtn, hasErrorMsg, ariaLabel, children } = btnProps;
-  const { handleClick, customStyle, className } = btnProps;
+  const { handleClick, customStyle, className, disabled } = btnProps;
 
   return (
     <button
+      disabled={disabled}
       type="button"
       onClick={handleClick}
       style={customStyle}
@@ -29,6 +32,7 @@ function ButtonView(btnProps: Props) {
         className,
         { [$['icon-btn']]: iconBtn },
         { [$.error]: hasErrorMsg },
+        { [$.disabled]: disabled },
       )}
       aria-label={ariaLabel}
     >

--- a/src/components/shared/atoms/Button/Button.view.tsx
+++ b/src/components/shared/atoms/Button/Button.view.tsx
@@ -1,4 +1,5 @@
-import { CSSProperties } from 'react';
+/* eslint-disable react/button-has-type */
+import { ButtonHTMLAttributes, CSSProperties } from 'react';
 
 import type { DefaultProps } from '#types/props';
 import classnames from 'classnames';
@@ -6,25 +7,27 @@ import classnames from 'classnames';
 import $ from './style.module.scss';
 
 export type ButtonProps = {
+  type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
   handleClick?: () => void;
   iconBtn?: boolean;
   hasErrorMsg?: boolean;
   disabled?: boolean;
 } & DefaultProps;
 
-type Props = {
+type Props = ButtonProps & {
+  type: NonNullable<ButtonProps['type']>;
   customStyle: CSSProperties;
   ariaLabel: string;
-} & ButtonProps;
+};
 
 function ButtonView(btnProps: Props) {
-  const { iconBtn, hasErrorMsg, ariaLabel, children } = btnProps;
+  const { iconBtn, hasErrorMsg, ariaLabel, children, type } = btnProps;
   const { handleClick, customStyle, className, disabled } = btnProps;
 
   return (
     <button
       disabled={disabled}
-      type="button"
+      type={type || 'button'}
       onClick={handleClick}
       style={customStyle}
       className={classnames(

--- a/src/components/shared/atoms/Button/index.tsx
+++ b/src/components/shared/atoms/Button/index.tsx
@@ -15,7 +15,7 @@ type Props<T> = {
 function Button<T>(btnProps: Props<T>) {
   const { color, fontWeight, borderRadius, value, disabled } = btnProps;
   const { label, iconBtn, background, onClick, hasErrorMsg } = btnProps;
-  const { className, style, children } = btnProps;
+  const { className, style, children, type } = btnProps;
   const ariaLabel = label || `${children}`;
   const customStyle = {
     ...style,
@@ -32,6 +32,7 @@ function Button<T>(btnProps: Props<T>) {
   return (
     <ButtonView
       {...{
+        type: type || 'button',
         handleClick: onClick ? handleClick : undefined,
         customStyle,
         className,

--- a/src/components/shared/atoms/Button/index.tsx
+++ b/src/components/shared/atoms/Button/index.tsx
@@ -1,23 +1,19 @@
 import { memo } from 'react';
 
-import type { DefaultProps } from '#types/props';
-
-import ButtonView from './Button.view';
+import ButtonView, { ButtonProps } from './Button.view';
 
 type Props<T> = {
   color?: string;
   fontWeight?: number;
   label?: string;
-  iconBtn?: boolean;
   background?: string;
   borderRadius?: string;
   onClick?: (value?: T) => void;
   value?: T;
-  hasErrorMsg?: boolean;
-} & DefaultProps;
+} & ButtonProps;
 
 function Button<T>(btnProps: Props<T>) {
-  const { color, fontWeight, borderRadius, value } = btnProps;
+  const { color, fontWeight, borderRadius, value, disabled } = btnProps;
   const { label, iconBtn, background, onClick, hasErrorMsg } = btnProps;
   const { className, style, children } = btnProps;
   const ariaLabel = label || `${children}`;
@@ -43,6 +39,7 @@ function Button<T>(btnProps: Props<T>) {
         hasErrorMsg,
         ariaLabel,
         children,
+        disabled,
       }}
     />
   );

--- a/src/components/shared/atoms/Button/style.module.scss
+++ b/src/components/shared/atoms/Button/style.module.scss
@@ -16,3 +16,7 @@
   border: 2px solid $third;
   box-sizing: border-box;
 }
+.disabled {
+  background-color: $gray-280;
+  cursor: not-allowed;
+}

--- a/src/components/shared/molecules/ButtonFooter/ButtonFooter.stories.tsx
+++ b/src/components/shared/molecules/ButtonFooter/ButtonFooter.stories.tsx
@@ -31,6 +31,11 @@ export default {
         type: 'text',
       },
     },
+    disabled: {
+      control: {
+        type: 'boolean',
+      },
+    },
   },
 } as ComponentMeta<typeof ButtonFooter>;
 
@@ -44,4 +49,5 @@ Default.args = {
   background: '#fff',
   msg: '오류 메시지',
   children: '다음',
+  disabled: false,
 };

--- a/src/components/shared/molecules/ButtonFooter/index.tsx
+++ b/src/components/shared/molecules/ButtonFooter/index.tsx
@@ -11,11 +11,12 @@ type Props = {
   onClick?: () => void;
   LeftBtn?: JSX.Element;
   msg?: string;
+  disabled?: boolean;
 } & DefaultProps;
 
 export default function ButtonFooter(footerProps: Props) {
   const { className, style, LeftBtn, children } = footerProps;
-  const { btnColor, background, onClick, msg } = footerProps;
+  const { btnColor, background, onClick, msg, disabled } = footerProps;
   return (
     <FooterWrapper
       className={classnames($['btn-footer'], className)}
@@ -29,6 +30,7 @@ export default function ButtonFooter(footerProps: Props) {
         hasErrorMsg={!!msg}
         onClick={onClick}
         className={$.btn}
+        disabled={disabled}
       >
         {children}
       </Button>

--- a/src/components/shared/molecules/ButtonFooter/index.tsx
+++ b/src/components/shared/molecules/ButtonFooter/index.tsx
@@ -1,11 +1,13 @@
 import type { DefaultProps } from '#types/props';
 import Button from '@atoms/Button';
+import { ButtonProps } from '@atoms/Button/Button.view';
 import FooterWrapper from '@molecules/FooterWrapper';
 import classnames from 'classnames';
 
 import $ from './style.module.scss';
 
 type Props = {
+  type?: ButtonProps['type'];
   btnColor?: string;
   background?: string;
   onClick?: () => void;
@@ -15,7 +17,7 @@ type Props = {
 } & DefaultProps;
 
 export default function ButtonFooter(footerProps: Props) {
-  const { className, style, LeftBtn, children } = footerProps;
+  const { className, style, LeftBtn, children, type } = footerProps;
   const { btnColor, background, onClick, msg, disabled } = footerProps;
   return (
     <FooterWrapper
@@ -26,11 +28,11 @@ export default function ButtonFooter(footerProps: Props) {
     >
       {LeftBtn}
       <Button
+        {...{ type, disabled }}
         background={btnColor}
         hasErrorMsg={!!msg}
         onClick={onClick}
         className={$.btn}
-        disabled={disabled}
       >
         {children}
       </Button>

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -10,10 +10,11 @@ import Layout from '@templates/Layout';
 import UploadTemplate from '@templates/UploadTemplate';
 import { getSelectedCategory } from 'src/api/category';
 import { getStaticData } from 'src/api/staticData';
+import ContinueWriteModal from 'src/components/Upload/organisms/ContinueWriteModal';
 import { useAuthTest } from 'src/hooks/api/login';
 import { useUploadStore } from 'src/store/upload/useUploadStore';
 import { toastError } from 'src/utils/toaster';
-import { judgeValid } from 'src/utils/upload.utils';
+import { isUploadRemained } from 'src/utils/upload.utils';
 
 export const getStaticProps = async () => {
   const queryClient = new QueryClient();
@@ -53,13 +54,13 @@ function Upload() {
   const router = useRouter();
   const { isSuccess } = useAuthTest();
   const states = useUploadStore((state) => state);
-  const { isRemainState } = judgeValid(states);
+  const isRemainState = isUploadRemained(states);
 
   const backBtnClick = useCallback(() => {
-    if (isRemainState && isSuccess) {
+    if (isRemainState) {
       toastError({ message: '상품이 임시저장되었습니다.' });
     }
-  }, [isRemainState, isSuccess]);
+  }, [isRemainState]);
 
   useEffect(() => {
     router.events.on('routeChangeStart', backBtnClick);
@@ -68,9 +69,14 @@ function Upload() {
     };
   }, [backBtnClick, router.events, router.pathname]);
 
-  if (isSuccess)
-    return <UploadTemplate {...{ id: '-1', states, isUpdate: false }} />;
-  return <Loading style={{ height: 'calc(var(--vh, 1vh) * 100)' }} />;
+  if (!isSuccess)
+    return <Loading style={{ height: 'calc(var(--vh, 1vh) * 100)' }} />;
+  return (
+    <>
+      <ContinueWriteModal {...{ isRemainState, clear: states.clearUpload }} />
+      <UploadTemplate {...{ id: '-1', states, isUpdate: false }} />
+    </>
+  );
 }
 
 Upload.getLayout = function getLayout(page: ReactElement) {

--- a/src/store/constants.ts
+++ b/src/store/constants.ts
@@ -42,6 +42,15 @@ export const filterInitialState: FilterState = {
 };
 
 export const uploadInitialState: UploadState = {
+  validation: {
+    imgList: false,
+    style: false,
+    price: false,
+    basicInfo: false,
+    sellerNote: false,
+    size: false,
+    contact: false,
+  },
   imgList: [], // TODO: refine
   contact: '',
   style: {

--- a/src/store/upload/UploadSlice.ts
+++ b/src/store/upload/UploadSlice.ts
@@ -1,5 +1,9 @@
 import { ImgBasicProps } from '#types/index';
-import { UploadStoreState, Measure } from '#types/storeType/upload';
+import {
+  UploadStoreState,
+  Measure,
+  ValidationKey,
+} from '#types/storeType/upload';
 import { isObjectType, uploadInitialState } from 'src/store/constants';
 import { deepClone, updateInfo } from 'src/utils';
 import { StateCreator } from 'zustand';
@@ -13,6 +17,15 @@ export const createUploadSlice: StateCreator<
   UploadSlice
 > = (set) => ({
   ...uploadInitialState,
+  updateValidate: (type: ValidationKey, isValidate: boolean) => {
+    set((state) => ({
+      ...state,
+      validation: {
+        ...state.validation,
+        [type]: isValidate,
+      },
+    }));
+  },
   imgUpload: (imgList: ({ id: number } & ImgBasicProps)[]) => {
     set((state) => {
       return {

--- a/src/types/storeType/upload.ts
+++ b/src/types/storeType/upload.ts
@@ -1,5 +1,18 @@
 import { ImgBasicProps } from '..';
 
+export type ValidationKey =
+  | 'imgList'
+  | 'style'
+  | 'price'
+  | 'basicInfo'
+  | 'sellerNote'
+  | 'size'
+  | 'contact';
+
+export type UploadValidation = {
+  [key in ValidationKey]: boolean;
+};
+
 export interface ImgList {
   id: number;
   src: string;
@@ -46,6 +59,7 @@ export interface AdditionalInfo {
 export type MeasureType = 'top' | 'bottom' | 'onepiece' | 'skirt';
 
 export interface UploadState {
+  validation: UploadValidation;
   imgList: ImgList[];
   contact: string;
   style: StyleUpload;
@@ -83,6 +97,7 @@ export type UpdateArr = (
 ) => void;
 
 export interface UploadStoreState extends UploadState {
+  updateValidate: (type: ValidationKey, value: boolean) => void;
   imgUpload: (imgList: ({ id: number } & ImgBasicProps)[]) => void;
   removeImg: (removeId: number) => void;
   initMeasure: (measures: Measure) => void;

--- a/src/utils/upload.utils.ts
+++ b/src/utils/upload.utils.ts
@@ -10,28 +10,20 @@ const judgeValid = (states: UploadState) => {
     states;
   const { imgList, price, size, contact } = validation;
 
-  const colorValid = !!style.color.length;
-  const tagValid = !!style.tag;
-  const materialValid = !!style.material;
-  const titleValid = !!basicInfo.title;
-  const categorySomeValid = !!basicInfo.category.some((x) => !!x);
-  const brandValid = !!basicInfo.brand;
-  const sellerSomeValid = Object.values(sellerNote).some((x) => !!x);
-
   return {
     isRemainState:
       imgList ||
       price ||
       size ||
       contact ||
-      colorValid ||
-      tagValid ||
-      materialValid ||
       isIncludeDelivery ||
-      titleValid ||
-      categorySomeValid ||
-      brandValid ||
-      sellerSomeValid,
+      !!style.color.length ||
+      !!style.tag ||
+      !!style.material ||
+      !!basicInfo.title ||
+      !!basicInfo.category.some((x) => !!x) ||
+      !!basicInfo.brand ||
+      Object.values(sellerNote).some((x) => !!x),
     isFormValid: Object.values(validation).every((x) => x),
   };
 };

--- a/src/utils/upload.utils.ts
+++ b/src/utils/upload.utils.ts
@@ -6,57 +6,33 @@ import { uploadInitialState } from 'src/store/constants';
 import { arrToString } from './arrToString';
 
 const judgeValid = (states: UploadState) => {
-  const { imgList, style, price, isIncludeDelivery, basicInfo } = states;
-  const { size, sellerNote, contact } = states;
-  const { title, category, brand } = basicInfo;
-  const imgListValid = !!imgList.length;
+  const { validation, style, isIncludeDelivery, basicInfo, sellerNote } =
+    states;
+  const { imgList, price, size, contact } = validation;
+
   const colorValid = !!style.color.length;
   const tagValid = !!style.tag;
   const materialValid = !!style.material;
-  const priceValid = !!price;
-  const deliveryValid = isIncludeDelivery;
-  const titleValid = !!title;
-  const categoryValid = !!category.every((x) => !!x);
-  const categorySomeValid = !!category.some((x) => !!x);
-  const brandValid = !!brand;
-  const sellerValid = Object.values(sellerNote).every((x) => !!x);
+  const titleValid = !!basicInfo.title;
+  const categorySomeValid = !!basicInfo.category.some((x) => !!x);
+  const brandValid = !!basicInfo.brand;
   const sellerSomeValid = Object.values(sellerNote).some((x) => !!x);
-  const sizeValid = !!size;
-  const contactValid = !!contact;
 
   return {
     isRemainState:
-      imgListValid ||
+      imgList ||
+      price ||
+      size ||
+      contact ||
       colorValid ||
       tagValid ||
       materialValid ||
-      priceValid ||
-      deliveryValid ||
+      isIncludeDelivery ||
       titleValid ||
       categorySomeValid ||
       brandValid ||
-      sellerSomeValid ||
-      contactValid ||
-      sizeValid,
-    isFormValid:
-      imgListValid &&
-      colorValid &&
-      tagValid &&
-      materialValid &&
-      priceValid &&
-      titleValid &&
-      categoryValid &&
-      brandValid &&
-      sellerValid &&
-      contactValid &&
-      sizeValid,
-    isImgValid: imgListValid,
-    isStyleValid: colorValid && tagValid && materialValid,
-    isPriceValid: priceValid,
-    isBasicValid: titleValid && categoryValid && brandValid,
-    isSellerValid: sellerValid,
-    isSizeValid: sizeValid,
-    isContactValid: contactValid,
+      sellerSomeValid,
+    isFormValid: Object.values(validation).every((x) => x),
   };
 };
 

--- a/src/utils/upload.utils.ts
+++ b/src/utils/upload.utils.ts
@@ -5,27 +5,25 @@ import { uploadInitialState } from 'src/store/constants';
 
 import { arrToString } from './arrToString';
 
-const judgeValid = (states: UploadState) => {
+const isUploadRemained = (states: UploadState) => {
   const { validation, style, isIncludeDelivery, basicInfo, sellerNote } =
     states;
   const { imgList, price, size, contact } = validation;
 
-  return {
-    isRemainState:
-      imgList ||
-      price ||
-      size ||
-      contact ||
-      isIncludeDelivery ||
-      !!style.color.length ||
-      !!style.tag ||
-      !!style.material ||
-      !!basicInfo.title ||
-      !!basicInfo.category.some((x) => !!x) ||
-      !!basicInfo.brand ||
-      Object.values(sellerNote).some((x) => !!x),
-    isFormValid: Object.values(validation).every((x) => x),
-  };
+  return (
+    imgList ||
+    price ||
+    size ||
+    contact ||
+    isIncludeDelivery ||
+    !!style.color.length ||
+    !!style.tag ||
+    !!style.material ||
+    !!basicInfo.title ||
+    !!basicInfo.category.some((x) => !!x) ||
+    !!basicInfo.brand ||
+    Object.values(sellerNote).some((x) => !!x)
+  );
 };
 
 const refineUploadData = (data: UploadStoreState): req.UploadData => {
@@ -92,4 +90,4 @@ const uploadedDataToState = (
   };
 };
 
-export { judgeValid, refineUploadData, uploadedDataToState };
+export { isUploadRemained, refineUploadData, uploadedDataToState };

--- a/src/utils/upload.utils.ts
+++ b/src/utils/upload.utils.ts
@@ -30,11 +30,15 @@ const judgeValid = (states: UploadState) => {
 
 const refineUploadData = (data: UploadStoreState): req.UploadData => {
   const {
+    validation,
     imgUpload,
     removeImg,
     updateUpload,
     clearMeasure,
     clearUpload,
+    updateArr,
+    updateValidate,
+    initMeasure,
     ...rest
   } = data;
   const { imgList, measure, basicInfo, style } = rest;


### PR DESCRIPTION
## 💡 이슈

resolve #201 

## 🤩 개요

상품 업로드 페이지 리팩토링

## 🧑‍💻 작업 사항

1. 데이터에 맞는 컴포넌트에서 state를 선언하기. 페이지에서 state를 불러와서 props drilling 방지.
2. validation 전역 상태로 두기
3. validation 로직을 각 컴포넌트에서 관리하고 각 컴포넌트에서 상태가 바뀌면 validation돌리고 isValidate 상태 변경하기
4. 메모이제이션 전후 렌더링 측정하기

### 리팩토링 효과
1. 위 리팩토링 과정으로 인해 `UploadTemplate`에서 담당했던 로직을 각 컴포넌트로 분산함으로써 복잡성을 줄일 수 있었습니다.
2. 페이지에서 컴포넌트의 모든 validation을 관리했던 점을 개선하기 위해 각 컴포넌트에서 validation을 담당하여 colocation이 가능해졌습니다.
3. 각 컴포넌트에 대한 validation 데이터를 전역 상태로 옮김에 따라 코드 라인이 증가하였습니다.
4. 리렌더링을 방지하기 위해 전역 상태로부터 필요한 데이터만 불러오게 되어 코드 라인이 증가하였습니다.

## 📖 참고 사항
### 렌더링 최적화 전

![1](https://user-images.githubusercontent.com/62797441/226475203-4748c7f1-ddb8-4d41-aad7-a59c3badd0dd.png)
**평균 6.08ms**

### 렌더링 최적화 후
![2](https://user-images.githubusercontent.com/62797441/226475488-c642aaf8-659d-4a40-84b6-ba439242664a.png)

![2-2](https://user-images.githubusercontent.com/62797441/226475519-9dac85d5-546d-42cc-8bc4-6a213981ebb3.png)
**평균 1.2ms ~ 2.5ms** 범위로 형성되었습니다.

**평균 6.08ms**에서 **평균 1.2ms ~ 2.5ms**로 개선되었습니다.

