### PR TITLE
[Refactor] 상품 업로드 컴포넌트 validation hook으로 공통화

### DIFF
--- a/src/components/Upload/organisms/Basic/index.tsx
+++ b/src/components/Upload/organisms/Basic/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { UploadTemplateWithCategory } from '#types/upload';
 import Button from '@atoms/Button';
@@ -8,6 +8,7 @@ import InfoArticle from '@molecules/InfoArticle';
 import TextInput from '@molecules/TextInput';
 import { getBreadcrumb, getCategoryTree } from 'src/api/category';
 import useDebounceInput from 'src/hooks/useDebounceInput';
+import useUploadFormValidate from 'src/hooks/useUploadFormValidate';
 import { useUploadUpdateStore } from 'src/hooks/useUploadUpdateStore';
 
 import Dialog from '../Dialog';
@@ -20,13 +21,9 @@ function Basic(basicProps: UploadTemplateWithCategory) {
   const useStore = useUploadUpdateStore(isUpdate);
   const state = useStore((states) => states.basicInfo);
   const onChange = useStore((states) => states.updateUpload);
-  const updateValidate = useStore((states) => states.updateValidate);
   const { category, curCategoryIdx } = state;
   const isBasicValid = basicValidate(state);
-
-  useEffect(() => {
-    updateValidate('basicInfo', isBasicValid);
-  }, [isBasicValid, updateValidate]);
+  useUploadFormValidate({ isUpdate, isValid: isBasicValid, type: 'basicInfo' });
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const openDialog = useCallback(() => setDialogOpen(true), []);

--- a/src/components/Upload/organisms/Contact/index.tsx
+++ b/src/components/Upload/organisms/Contact/index.tsx
@@ -1,10 +1,9 @@
-import { useEffect } from 'react';
-
 import { UploadUpdateProps } from '#types/upload';
 import ErrorMsg from '@atoms/ErrorMsg';
 import InfoArticle from '@molecules/InfoArticle';
 import TextInput from '@molecules/TextInput';
 import useDebounceInput from 'src/hooks/useDebounceInput';
+import useUploadFormValidate from 'src/hooks/useUploadFormValidate';
 import { useUploadUpdateStore } from 'src/hooks/useUploadUpdateStore';
 
 import $ from './style.module.scss';
@@ -16,16 +15,12 @@ function Contact({ isUpdate }: Props) {
   const useStore = useUploadUpdateStore(isUpdate);
   const state = useStore((states) => states.contact);
   const onChange = useStore((states) => states.updateUpload);
-  const updateValidate = useStore((states) => states.updateValidate);
   const isContactValid = contactValidate(state);
   const handleInput = useDebounceInput(onChange, 200);
+  useUploadFormValidate({ isUpdate, isValid: isContactValid, type: 'contact' });
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     handleInput(e.target.value, 'contact');
-
-  useEffect(() => {
-    updateValidate('contact', isContactValid);
-  }, [isContactValid, updateValidate]);
 
   return (
     <InfoArticle

--- a/src/components/Upload/organisms/ImgUpload/index.tsx
+++ b/src/components/Upload/organisms/ImgUpload/index.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { recognitionResult, UploadUpdateProps } from '#types/upload';
 import { getCategoryIds } from 'src/api/category';
 import { useImgUpload } from 'src/hooks/api/upload';
 import useSwiper from 'src/hooks/useSwiper';
+import useUploadFormValidate from 'src/hooks/useUploadFormValidate';
 import { useUploadUpdateStore } from 'src/hooks/useUploadUpdateStore';
 
 import ImgUploadView from './ImgUploadView';
@@ -22,7 +23,6 @@ function ImgUpload(imgProps: Props) {
   const updateArr = useStore((states) => states.updateArr);
   const imgUpload = useStore((states) => states.imgUpload);
   const removeImg = useStore((states) => states.removeImg);
-  const updateValidate = useStore((states) => states.updateValidate);
   const [imgResult, setImgResult] = useState<recognitionResult>({});
   const inputRef = useRef<HTMLInputElement>(null);
   const uploadRef = useRef<HTMLDivElement>(null);
@@ -30,9 +30,7 @@ function ImgUpload(imgProps: Props) {
   const isImgValid = imgListValidate(imgList);
 
   useSwiper(uploadRef);
-  useEffect(() => {
-    updateValidate('imgList', isImgValid);
-  }, [isImgValid, updateValidate]);
+  useUploadFormValidate({ isUpdate, isValid: isImgValid, type: 'imgList' });
 
   const onUploadClick = () => {
     if (inputRef.current) inputRef.current.click();

--- a/src/components/Upload/organisms/Price/index.tsx
+++ b/src/components/Upload/organisms/Price/index.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from 'react';
-
 import { UploadState } from '#types/storeType/upload';
 import { UploadUpdateProps } from '#types/upload';
 import ErrorMsg from '@atoms/ErrorMsg';
@@ -10,6 +8,7 @@ import TextInput from '@molecules/TextInput';
 import classnames from 'classnames';
 import { max } from 'src/components/Shop/Organisms/FilterModal/constants';
 import useDebounceInput from 'src/hooks/useDebounceInput';
+import useUploadFormValidate from 'src/hooks/useUploadFormValidate';
 import { useUploadUpdateStore } from 'src/hooks/useUploadUpdateStore';
 import { filterMaxPrice } from 'src/utils';
 
@@ -19,23 +18,20 @@ import { priceValidate } from './validate';
 function Price({ isUpdate }: UploadUpdateProps) {
   const useStore = useUploadUpdateStore(isUpdate);
   const price = useStore((states) => states.price);
-  const isPriceValid = priceValidate(price);
   const isIncludeDelivery = useStore((states) => states.isIncludeDelivery);
+  const isPriceValid = priceValidate(price);
   const onChange = useStore((states) => states.updateUpload);
-  const updateValidate = useStore((states) => states.updateValidate);
+  useUploadFormValidate({ isUpdate, isValid: isPriceValid, type: 'price' });
   const handleInput = useDebounceInput<[number, keyof UploadState, undefined]>(
     onChange,
     200,
   );
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const num = filterMaxPrice(e.target.value, max);
     e.target.value = num;
     handleInput(+num, 'price', undefined);
   };
-
-  useEffect(() => {
-    updateValidate('price', isPriceValid);
-  }, [isPriceValid, updateValidate]);
 
   return (
     <InfoArticle label="판매가격 설정" required>

--- a/src/components/Upload/organisms/SellerReview/index.tsx
+++ b/src/components/Upload/organisms/SellerReview/index.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from 'react';
-
 import { UploadTemplateWithCategory } from '#types/upload';
 import ErrorMsg from '@atoms/ErrorMsg';
 import Span from '@atoms/Span';
@@ -9,6 +7,7 @@ import SelectBox from '@molecules/SelectBox';
 import TextInput from '@molecules/TextInput';
 import { getMainCategory } from 'src/api/category';
 import useDebounceInput from 'src/hooks/useDebounceInput';
+import useUploadFormValidate from 'src/hooks/useUploadFormValidate';
 import { useUploadUpdateStore } from 'src/hooks/useUploadUpdateStore';
 import { filterHeight } from 'src/utils/filterValue';
 
@@ -25,11 +24,16 @@ function SellerReview({ isUpdate, reviewDatas, categoryData }: Props) {
   const category = useStore((states) => states.basicInfo.category);
   const state = useStore((states) => states.sellerNote);
   const onChange = useStore((states) => states.updateUpload);
-  const updateValidate = useStore((states) => states.updateValidate);
   const isSellerValid = sellerReviewValidate(state);
   const data = reviewData(getMainCategory(categoryData, category), reviewDatas);
   const { condition, pollution, fit, bodyShapes, length } = data;
   const optionsData = [condition, pollution, length, fit];
+
+  useUploadFormValidate({
+    isUpdate,
+    isValid: isSellerValid,
+    type: 'sellerNote',
+  });
 
   const handleInput = useDebounceInput(onChange, 200);
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -37,10 +41,6 @@ function SellerReview({ isUpdate, reviewDatas, categoryData }: Props) {
     e.target.value = value;
     handleInput(+value, 'sellerNote', 'height');
   };
-
-  useEffect(() => {
-    updateValidate('sellerNote', isSellerValid);
-  }, [isSellerValid, updateValidate]);
 
   return (
     <InfoArticle label="쉽게 작성하는 후기" required>

--- a/src/components/Upload/organisms/SizeInfo/index.tsx
+++ b/src/components/Upload/organisms/SizeInfo/index.tsx
@@ -1,10 +1,9 @@
-import { useEffect } from 'react';
-
 import { UploadTemplateWithCategory } from '#types/upload';
 import ErrorMsg from '@atoms/ErrorMsg';
 import { sizeData } from '@constants/upload/utils';
 import InfoBtnBox from '@organisms/InfoBtnBox';
 import { getMainCategory } from 'src/api/category';
+import useUploadFormValidate from 'src/hooks/useUploadFormValidate';
 import { useUploadUpdateStore } from 'src/hooks/useUploadUpdateStore';
 
 import { sizeValidate } from './validate';
@@ -19,13 +18,9 @@ function SizeInfo(infoProps: Props) {
   const state = useStore((states) => states.size);
   const category = useStore((states) => states.basicInfo.category);
   const onChange = useStore((states) => states.updateUpload);
-  const updateValidate = useStore((states) => states.updateValidate);
   const isSizeValid = sizeValidate(state);
   const sizeProps = sizeData(getMainCategory(categoryData, category), sizes);
-
-  useEffect(() => {
-    updateValidate('size', isSizeValid);
-  }, [isSizeValid, updateValidate]);
+  useUploadFormValidate({ isUpdate, isValid: isSizeValid, type: 'size' });
 
   return (
     <InfoBtnBox

--- a/src/components/Upload/organisms/StyleSelect/index.tsx
+++ b/src/components/Upload/organisms/StyleSelect/index.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from 'react';
-
 import { DefaultData } from '#types/index';
 import { btnTemplateBox } from '#types/info';
 import { StyleUpload, UploadState } from '#types/storeType/upload';
@@ -8,7 +6,7 @@ import ErrorMsg from '@atoms/ErrorMsg';
 import InfoArticle from '@molecules/InfoArticle';
 import TextInput from '@molecules/TextInput';
 import InfoBtnBox from '@organisms/InfoBtnBox';
-import useDebounceInput from 'src/hooks/useDebounceInput';
+import useUploadFormValidate from 'src/hooks/useUploadFormValidate';
 import { useUploadUpdateStore } from 'src/hooks/useUploadUpdateStore';
 
 import $ from './style.module.scss';
@@ -29,16 +27,10 @@ function StyleSelect(styleProps: Props) {
   const state = useStore((states) => states.style);
   const isStyleValid = styleValidate(state);
   const onChange = useStore((states) => states.updateUpload);
-  const updateValidate = useStore((states) => states.updateValidate);
-  const handleInput = useDebounceInput(onChange, 200);
-  const handleChange =
-    // Todo: 성능 최적화
-    (e: React.ChangeEvent<HTMLInputElement>) =>
-      onChange(e.target.value, 'style', 'material');
+  useUploadFormValidate({ isUpdate, isValid: isStyleValid, type: 'style' });
 
-  useEffect(() => {
-    updateValidate('style', isStyleValid);
-  }, [isStyleValid, updateValidate]);
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+    onChange(e.target.value, 'style', 'material');
 
   return (
     <InfoArticle
@@ -59,7 +51,7 @@ function StyleSelect(styleProps: Props) {
       <InfoArticle label="소재" childrenBox>
         <TextInput
           className={$.material}
-          controlled // 성능 최적화
+          controlled
           value={state.material}
           placeholder="코튼 등"
           onChange={handleChange}

--- a/src/hooks/useUploadFormValidate.ts
+++ b/src/hooks/useUploadFormValidate.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+import { ValidationKey } from '#types/storeType/upload';
+
+import { useUploadUpdateStore } from './useUploadUpdateStore';
+
+type Props = {
+  isUpdate: boolean;
+  type: ValidationKey;
+  isValid: boolean;
+};
+
+export default function useUploadFormValidate(props: Props) {
+  const { isUpdate, type, isValid } = props;
+  const useStore = useUploadUpdateStore(isUpdate);
+  const updateValidate = useStore((states) => states.updateValidate);
+
+  useEffect(() => {
+    updateValidate(type, isValid);
+  }, [isValid, type, updateValidate]);
+}


### PR DESCRIPTION
## 💡 이슈

resolve #214 

## 🤩 개요

상품 업로드 컴포넌트 validation hook으로 공통화

## 🧑‍💻 작업 사항

효과
- 각 컴포넌트에서는 매번 useEffect, updateValidate를 불러오지 않고 useUploadFormValidate 훅 하나만 불러올 수 있음
- 코드량이 적어지고 불필요하게 반복되는 로직을 공통화 함.

## 📖 참고 사항

공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.
